### PR TITLE
Extending the Format String Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MCC is a MineCraft Client API written in C. Its purpose is to enable automation 
 
 ## Packet Format Guide ##
 
-Structs can be serialized to bytes by defining a format string for the packet serializer. The following table describes the format guidelines.
+Structs can be serialized to bytes by defining a format string for the packet serializer. The following table contains the available element types:
 
 | fmt | type     |
 | --- | -------- |
@@ -24,6 +24,13 @@ Structs can be serialized to bytes by defining a format string for the packet se
 | `q` | 16 bytes |
 | `s` | string   |
 | `v` | varint32 |
-| `*` | array    |
 
-Note: the array format character is a prefix to other types or groups of types (e.g. `*b` for a char array).
+In addition, the format language supports the following control structures:
+
+| fmt | type |
+| --- | ---- |
+| `*` | primitive array |
+| `*()` | struct array |
+| `[|]` | choice block |
+
+Each control structure uses the value of the preceding primitive element as its count. Each member of a choice block or struct array is read as a separate format string; as such control structures can be nested (but please use caution).

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Structs can be serialized to bytes by defining a format string for the packet se
 | `v` | varint32 |
 | `*` | array    |
 
-Note: the array format character is a prefix to other types (e.g. `*b` for a char array).
+Note: the array format character is a prefix to other types or groups of types (e.g. `*b` for a char array).

--- a/src/marshal.c
+++ b/src/marshal.c
@@ -110,17 +110,17 @@ size_t format_sizeof(char *c)
 {
     // Special case to support struct arrays
     if(*c == '(') {
-        size_t arr = 0;
+        size_t len = 0;
         int depth = 1;
         c++;
         do {
             if(depth == 1) {
-                arr += format_sizeof(c);
+                len += format_sizeof(c);
             }
             c++;
             if(*c == '[') {
             // When we hit a choice, add the size of it
-              arr += format_sizeof(c);
+              len += format_sizeof(c);
               // Then pass over it
               int p_depth = 0;
               do {
@@ -141,7 +141,7 @@ size_t format_sizeof(char *c)
                 c++;
             }
         } while(depth > 0);
-        return arr;
+        return len;
     }
 
     // Special case to support option blocks
@@ -283,6 +283,12 @@ void reentrant_memmove(void *dest, void *src, size_t len)
 
 char *get_packet_sub_fmt(char *fmt, int start_index)
 {
+    // If told to get sub_fmt in an invalid location,
+    // this returns the whole string
+    if(fmt[start_index] != '(') {
+        return fmt;
+    }
+
     char *end = &fmt[start_index];
     int count = 0;
     int p_depth = 1;

--- a/src/marshal.h
+++ b/src/marshal.h
@@ -16,6 +16,7 @@ int varint32_encode(int32_t value, char *data, int len);
 
 void reverse(void *number, int len);
 
+char *get_packet_sub_fmt(char *fmt, int start_index);
 int format_packet(bot_t *bot, void *packet_data, void *packet_raw);
 int decode_packet(bot_t *bot, void *packet_raw, void *packet_data);
 void free_packet(void *);

--- a/src/marshal.h
+++ b/src/marshal.h
@@ -20,6 +20,6 @@ int format_packet(bot_t *bot, void *packet_data, void *packet_raw);
 int decode_packet(bot_t *bot, void *packet_raw, void *packet_data);
 void free_packet(void *);
 vint32_t peek_packet(bot_t *, void *);
-size_t format_sizeof(char);
+size_t format_sizeof(char *);
 void *push(void *, void *, size_t);
 __int128_t value_at(void *, size_t);

--- a/test/packet_test.c
+++ b/test/packet_test.c
@@ -176,11 +176,65 @@ int test_fmt_str(char *fmt)
 
 void format_sizeof_test()
 {
+    size_t goal;
+    char fmt[50];
     printf("Testing format_sizeof for *()\n");
-    // Test missing
+    goal = sizeof(int8_t) + sizeof(int32_t) + sizeof(void *);
+    strcpy(fmt, "(bws)lv");
+
+    if(goal != format_sizeof(fmt)) {
+        printf("format_sizeof does not support *()\n");
+        printf("goal:%lu actual:%lu\n", goal, format_sizeof(fmt));
+        return;
+    }
+
+    goal = sizeof(int8_t) + sizeof(vint32_t) + sizeof(void *);
+    strcpy(fmt, "(bv*(ws))lv");
+
+    if(goal != format_sizeof(fmt)) {
+        printf("format_sizeof does not support nested *()\n");
+        printf("goal:%lu actual:%lu\n", goal, format_sizeof(fmt));
+        return;
+    }
 
     printf("Testing format_sizeof for []\n");
-    // Test missing
+    goal = sizeof(int32_t) + sizeof(int32_t) + sizeof(int64_t);
+    strcpy(fmt, "[bv||wwl]lv");
+
+    if(goal != format_sizeof(fmt)) {
+        printf("format_sizeof does not support []\n");
+        printf("goal:%lu actual:%lu\n", goal, format_sizeof(fmt));
+        return;
+    }
+
+    goal = sizeof(int32_t) + sizeof(int32_t) + sizeof(int64_t) + sizeof(int8_t) + sizeof(int64_t);
+    strcpy(fmt, "[bvb[|w]||wwlb[l|w]]lv");
+
+    if(goal != format_sizeof(fmt)) {
+        printf("format_sizeof does not support nested []\n");
+        printf("goal:%lu actual:%lu\n", goal, format_sizeof(fmt));
+        return;
+    }
+
+    goal = sizeof(int32_t) + sizeof(vint32_t) + sizeof(void *);
+    strcpy(fmt, "[b[|w]|wv*(ws)|b[h|w]]lv");
+
+    if(goal != format_sizeof(fmt)) {
+        printf("format_sizeof does not support *() within []\n");
+        printf("goal:%lu actual:%lu\n", goal, format_sizeof(fmt));
+        return;
+    }
+
+    goal = sizeof(int32_t) + sizeof(int8_t) + sizeof(int64_t);
+    strcpy(fmt, "(wb[h|l])lv");
+
+    if(goal != format_sizeof(fmt)) {
+        printf("format_sizeof does not support [] within *()\n");
+        printf("goal:%lu actual:%lu\n", goal, format_sizeof(fmt));
+        return;
+    }
+
+    printf("Passed all format_sizeof tests\n");
 }
 
 void packet_test(void)

--- a/test/packet_test.c
+++ b/test/packet_test.c
@@ -77,7 +77,7 @@ int packet_equals(void *p1, void *p2)
     size_t size;
     __int128_t arr_size = -1;
     while(*fmt) {
-        size = format_sizeof(*fmt);
+        size = format_sizeof(fmt);
         p1 = (void *)align(p1, size);
         p2 = (void *)align(p2, size);
         switch(*fmt) {
@@ -89,7 +89,7 @@ int packet_equals(void *p1, void *p2)
             break;
         case '*':
             fmt++;
-            size_t elem_size = format_sizeof(*fmt);
+            size_t elem_size = format_sizeof(fmt);
             if(memcmp(*(void **)p1, *(void **)p2, arr_size * elem_size)) {
                 printf("Array mismatch\n");
                 return 0;
@@ -133,9 +133,8 @@ int test_fmt_str(char *fmt)
     void *tmp = test + sizeof(void *);
     size_t arr_size;
     while(*fmt) {
-        size = format_sizeof(*fmt);
+        size = format_sizeof(fmt);
         tmp = (void *)align(tmp, size);
-        char var[5];
         switch(*fmt) {
         case 's': // varint followed by string
             // push random array size onto tmp
@@ -146,7 +145,7 @@ int test_fmt_str(char *fmt)
             break;
         case '*': // array
             fmt++;
-            size_t elem_size = format_sizeof(*fmt);
+            size_t elem_size = format_sizeof(fmt);
             void *arr = malloc(elem_size * arr_size);
             tmp = push(tmp, &arr, size);
             break;
@@ -175,6 +174,18 @@ int test_fmt_str(char *fmt)
     return equals;
 }
 
+void format_sizeof_test()
+{
+    printf("Testing format_sizeof for *()\n");
+    size_t goal = sizeof(int8_t) + sizeof(int32_t) + sizeof(void *);
+    char *fmt = "(bws)lv";
+
+    if(goal != format_sizeof(fmt))
+        printf("format_sizeof does not support *()\n");
+    else
+        printf("format_sizeof passed\n");
+}
+
 void packet_test(void)
 {
     char fmt[FORMAT_LENGTH + 1] = {0};
@@ -187,4 +198,6 @@ void packet_test(void)
         else
             printf("Format string %s failed\n", fmt);
     }
+
+    format_sizeof_test();
 }

--- a/test/packet_test.c
+++ b/test/packet_test.c
@@ -177,13 +177,10 @@ int test_fmt_str(char *fmt)
 void format_sizeof_test()
 {
     printf("Testing format_sizeof for *()\n");
-    size_t goal = sizeof(int8_t) + sizeof(int32_t) + sizeof(void *);
-    char *fmt = "(bws)lv";
+    // Test missing
 
-    if(goal != format_sizeof(fmt))
-        printf("format_sizeof does not support *()\n");
-    else
-        printf("format_sizeof passed\n");
+    printf("Testing format_sizeof for []\n");
+    // Test missing
 }
 
 void packet_test(void)


### PR DESCRIPTION
Adds choice blocks and struct arrays into the format string language.
There is test coverage on `format_sizeof`'s changes and the new `get_packet_sub_fmt`, but not on the new features of `free_packet`, `decode_packet`, or `format_packet`, which require new union definitions in order to be meaningful and some creativity to test.

All old functionality of the modified methods is preserved.