### PR TITLE
Another Big Request

### DIFF
--- a/sample/sample_slave.c
+++ b/sample/sample_slave.c
@@ -29,8 +29,8 @@ bot_t *init_slave(char *name, char *server_name, int port)
     bot->state = calloc(1, sizeof(bot_globals_t));
 
     register_defaults(bot);
-    register_event(bot, PLAY, 0x02, chat_handler);
-    register_event(bot, PLAY, 0x06, respawn_handler);
+    register_play_clientbound_chat(bot, mcc_chat_handler);
+    register_play_clientbound_update_health(bot, mcc_autorespawn_handler);
 
     login(bot, server_name, port);
 

--- a/src/api.c
+++ b/src/api.c
@@ -23,16 +23,6 @@ void msleep(uint64_t ms)
     } while (finished == -1);
 }
 
-void register_defaults(bot_t *bot)
-{
-    // Basic event handling that you should always want
-    register_event(bot, LOGIN, 0x02, login_success_handler);
-    register_event(bot, PLAY, 0x00, keepalive_handler);
-    register_event(bot, PLAY, 0x01, join_game_handler);
-    register_event(bot, PLAY, 0x06, update_health_handler);
-    register_event(bot, PLAY, 0x08, position_handler);
-}
-
 void login(bot_t *bot, char *server_address, int port)
 {
     join_server(bot, server_address, port);
@@ -829,4 +819,15 @@ void register_play_clientbound_set_compression(bot_t *bot,
     function *child = calloc(1, sizeof(function));
     parent->f = f;
     parent->next = child;
+}
+
+
+void register_defaults(bot_t *bot)
+{
+    // Basic event handling that you should always want
+    register_login_clientbound_success(bot, mcc_login_success_handler);
+    register_play_clientbound_keepalive(bot, mcc_keepalive_handler);
+    register_play_clientbound_join_game(bot, mcc_join_game_handler);
+    register_play_clientbound_update_health(bot, mcc_update_health_handler);
+    register_play_clientbound_position(bot, mcc_position_handler);
 }

--- a/src/api.c
+++ b/src/api.c
@@ -173,3 +173,609 @@ void set_pos(bot_t *bot, double x, double y, double z)
 
     send_play_serverbound_player_move(bot, x, y, z, true);
 }
+
+/* Functions to register callback handlers */
+
+void register_login_clientbound_disconnect(bot_t *bot, 
+        void (*f)(char *)){
+    function *parent = &bot->_data->callbacks[LOGIN][0x00];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_login_clientbound_success(bot_t *bot,
+        void (*f)(char *, char *)) {
+
+    function *parent = &bot->_data->callbacks[LOGIN][0x02];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_login_clientbound_set_compression(bot_t *bot,
+        void (*f)(vint32_t)) {
+    function *parent = &bot->_data->callbacks[LOGIN][0x03];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_status_clientbound_response(bot_t *bot,
+        void (*f)(char *)) {
+    function *parent = &bot->_data->callbacks[STATUS][0x00];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_status_clientbound_ping(bot_t *bot,
+        void (*f)(int64_t)) {
+    function *parent = &bot->_data->callbacks[STATUS][0x01];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_keepalive(bot_t *bot,
+        void (*f)(vint32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x00];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_join_game(bot_t *bot,
+        void (*f)(int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x01];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_chat(bot_t *bot,
+        void (*f)(char *, int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x02];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_time_update(bot_t *bot,
+        void (*f)(int64_t, int64_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x03];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_equipment(bot_t *bot,
+        void (*f)(vint32_t, int16_t, slot_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x04];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_spawn_position(bot_t *bot,
+        void (*f)(position_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x05];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_update_health(bot_t *bot,
+        void (*f)(float, vint32_t, float)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x06];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_respawn(bot_t *bot,
+        void (*f)(int32_t, uint8_t, uint8_t, char *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x07];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_position(bot_t *bot,
+        void (*f)(double, double, double, float, float, int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x08];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_item_change(bot_t *bot,
+        void (*f)(int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x09];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_use_bed(bot_t *bot,
+        void (*f)(vint32_t, position_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x0a];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_animation(bot_t *bot,
+        void (*f)(vint32_t, uint8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x0b];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_spawn_player(bot_t *bot,
+        void (*f)(vint32_t, 
+            __uint128_t, 
+            int32_t, 
+            int32_t, 
+            int32_t, 
+            int8_t, 
+            int8_t, 
+            int16_t,
+            metadata_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x0c];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_collect(bot_t *bot,
+        void (*f)(vint32_t, vint32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x0d];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_spawn_object(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int32_t,
+            int32_t,
+            int32_t,
+            int8_t,
+            int8_t,
+            data_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x0e];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_spawn_mob(bot_t *bot,
+        void (*f)(vint32_t,
+            uint8_t,
+            int32_t,
+            int32_t,
+            int32_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            int16_t,
+            int16_t,
+            int16_t,
+            metadata_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x0f];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_spawn_painting(bot_t *bot,
+        void (*f)(vint32_t, char *, position_t, uint8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x10];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_spawn_xp(bot_t *bot,
+        void (*f)(vint32_t, int32_t, int32_t, int32_t, int16_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x11];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_velocity(bot_t *bot,
+        void (*f)(vint32_t, int16_t, int16_t, int16_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x12];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_destroy_entities(bot_t *bot,
+        void (*f)(vint32_t, vint32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x13];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity(bot_t *bot,
+        void (*f)(vint32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x14];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_move(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            bool)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x15];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_look(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            bool,
+            int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x16];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_look_move(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            bool)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x17];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_teleport(bot_t *bot,
+        void (*f)(vint32_t,
+            int32_t,
+            int32_t,
+            int32_t,
+            int8_t,
+            int8_t,
+            bool)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x18];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_head_look(bot_t *bot,
+        void (*f)(vint32_t, int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x19];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_status(bot_t *bot,
+        void (*f)(int32_t, int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x1a];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_attach(bot_t *bot,
+        void (*f)(int32_t, int32_t, bool)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x1b];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_effect(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            vint32_t,
+            bool)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x1d];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_clear_effect(bot_t *bot,
+        void (*f)(vint32_t, int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x1e];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_set_xp(bot_t *bot,
+        void (*f)(float, int32_t, int32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x1f];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_properties(bot_t *bot,
+        void (*f)(vint32_t,
+            int32_t,
+            property_t *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x20];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_chunk_data(bot_t *bot,
+        void (*f)(int32_t,
+            int32_t,
+            bool,
+            uint16_t,
+            vint32_t,
+            int8_t *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x21];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_multi_block_change(bot_t *bot,
+        void (*f)(int32_t, int32_t, vint32_t, record_t *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x22];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_block_change(bot_t *bot,
+        void (*f)(position_t, vint32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x23];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_block_action(bot_t *bot,
+        void (*f)(position_t, uint8_t, uint8_t, vint32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x24];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_block_break_animation(bot_t *bot,
+        void (*f)(vint32_t, position_t, int8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x25];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_chunk_bulk(bot_t *bot,
+        void (*f)(bool,
+            vint32_t,
+            int32_t,
+            int32_t,
+            uint16_t,
+            int8_t *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x26];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_explosion(bot_t *bot,
+        void (*f)(float,
+            float,
+            float,
+            float,
+            int32_t,
+            record_t *,
+            float,
+            float,
+            float)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x27];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_effect(bot_t *bot,
+        void (*f)(int32_t, position_t, int32_t, bool)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x28];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_sound_effect(bot_t *bot,
+        void (*f)(char *,
+            int32_t,
+            int32_t,
+            int32_t,
+            float,
+            uint8_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x29];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_entity_spawn_global(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int32_t,
+            int32_t,
+            int32_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x2c];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_update_sign(bot_t *bot,
+        void (*f)(position_t,
+            chat_t,
+            chat_t,
+            chat_t,
+            chat_t)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x33];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_plugin_message(bot_t *bot,
+        void (*f)(char *, int8_t *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x3f];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_plugin_disconnect(bot_t *bot,
+        void (*f)(char *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x40];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_plugin_difficulty(bot_t *bot,
+        void (*f)(char *)) {
+    function *parent = &bot->_data->callbacks[PLAY][0x41];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}
+
+void register_play_clientbound_set_compression(bot_t *bot,
+        void (*f)()) {
+    function *parent = &bot->_data->callbacks[PLAY][0x46];
+    while(parent->next)
+        parent = parent->next;
+    function *child = calloc(1, sizeof(function));
+    parent->f = f;
+    parent->next = child;
+}

--- a/src/api.c
+++ b/src/api.c
@@ -175,8 +175,9 @@ void set_pos(bot_t *bot, double x, double y, double z)
 }
 
 
-void register_login_clientbound_disconnect(bot_t *bot, 
-        void (*f)(bot_t *, char *)){
+void register_login_clientbound_disconnect(bot_t *bot,
+        void (*f)(bot_t *, char *))
+{
     function *parent = &bot->_data->callbacks[LOGIN][0x00];
     while(parent->next)
         parent = parent->next;
@@ -186,7 +187,8 @@ void register_login_clientbound_disconnect(bot_t *bot,
 }
 
 void register_login_clientbound_success(bot_t *bot,
-        void (*f)(bot_t *, char *, char *)) {
+                                        void (*f)(bot_t *, char *, char *))
+{
 
     function *parent = &bot->_data->callbacks[LOGIN][0x02];
     while(parent->next)
@@ -197,7 +199,8 @@ void register_login_clientbound_success(bot_t *bot,
 }
 
 void register_login_clientbound_set_compression(bot_t *bot,
-        void (*f)(bot_t *, vint32_t)) {
+        void (*f)(bot_t *, vint32_t))
+{
     function *parent = &bot->_data->callbacks[LOGIN][0x03];
     while(parent->next)
         parent = parent->next;
@@ -207,7 +210,8 @@ void register_login_clientbound_set_compression(bot_t *bot,
 }
 
 void register_status_clientbound_response(bot_t *bot,
-        void (*f)(bot_t *, char *)) {
+        void (*f)(bot_t *, char *))
+{
     function *parent = &bot->_data->callbacks[STATUS][0x00];
     while(parent->next)
         parent = parent->next;
@@ -217,7 +221,8 @@ void register_status_clientbound_response(bot_t *bot,
 }
 
 void register_status_clientbound_ping(bot_t *bot,
-        void (*f)(bot_t *, int64_t)) {
+                                      void (*f)(bot_t *, int64_t))
+{
     function *parent = &bot->_data->callbacks[STATUS][0x01];
     while(parent->next)
         parent = parent->next;
@@ -227,7 +232,8 @@ void register_status_clientbound_ping(bot_t *bot,
 }
 
 void register_play_clientbound_keepalive(bot_t *bot,
-        void (*f)(bot_t *, vint32_t)) {
+        void (*f)(bot_t *, vint32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x00];
     while(parent->next)
         parent = parent->next;
@@ -237,7 +243,8 @@ void register_play_clientbound_keepalive(bot_t *bot,
 }
 
 void register_play_clientbound_join_game(bot_t *bot,
-        void (*f)(bot_t *, int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *)) {
+        void (*f)(bot_t *, int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x01];
     while(parent->next)
         parent = parent->next;
@@ -247,7 +254,8 @@ void register_play_clientbound_join_game(bot_t *bot,
 }
 
 void register_play_clientbound_chat(bot_t *bot,
-        void (*f)(bot_t *, char *, int8_t)) {
+                                    void (*f)(bot_t *, char *, int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x02];
     while(parent->next)
         parent = parent->next;
@@ -257,7 +265,8 @@ void register_play_clientbound_chat(bot_t *bot,
 }
 
 void register_play_clientbound_time_update(bot_t *bot,
-        void (*f)(bot_t *, int64_t, int64_t)) {
+        void (*f)(bot_t *, int64_t, int64_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x03];
     while(parent->next)
         parent = parent->next;
@@ -267,7 +276,8 @@ void register_play_clientbound_time_update(bot_t *bot,
 }
 
 void register_play_clientbound_entity_equipment(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, int16_t, slot_t)) {
+        void (*f)(bot_t *, vint32_t, int16_t, slot_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x04];
     while(parent->next)
         parent = parent->next;
@@ -277,7 +287,8 @@ void register_play_clientbound_entity_equipment(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_position(bot_t *bot,
-        void (*f)(bot_t *, position_t)) {
+        void (*f)(bot_t *, position_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x05];
     while(parent->next)
         parent = parent->next;
@@ -287,7 +298,8 @@ void register_play_clientbound_spawn_position(bot_t *bot,
 }
 
 void register_play_clientbound_update_health(bot_t *bot,
-        void (*f)(bot_t *, float, vint32_t, float)) {
+        void (*f)(bot_t *, float, vint32_t, float))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x06];
     while(parent->next)
         parent = parent->next;
@@ -297,7 +309,8 @@ void register_play_clientbound_update_health(bot_t *bot,
 }
 
 void register_play_clientbound_respawn(bot_t *bot,
-        void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *)) {
+                                       void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x07];
     while(parent->next)
         parent = parent->next;
@@ -307,7 +320,8 @@ void register_play_clientbound_respawn(bot_t *bot,
 }
 
 void register_play_clientbound_position(bot_t *bot,
-        void (*f)(bot_t *, double, double, double, float, float, int8_t)) {
+                                        void (*f)(bot_t *, double, double, double, float, float, int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x08];
     while(parent->next)
         parent = parent->next;
@@ -317,7 +331,8 @@ void register_play_clientbound_position(bot_t *bot,
 }
 
 void register_play_clientbound_item_change(bot_t *bot,
-        void (*f)(bot_t *, int8_t)) {
+        void (*f)(bot_t *, int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x09];
     while(parent->next)
         parent = parent->next;
@@ -327,7 +342,8 @@ void register_play_clientbound_item_change(bot_t *bot,
 }
 
 void register_play_clientbound_use_bed(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, position_t)) {
+                                       void (*f)(bot_t *, vint32_t, position_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x0a];
     while(parent->next)
         parent = parent->next;
@@ -337,7 +353,8 @@ void register_play_clientbound_use_bed(bot_t *bot,
 }
 
 void register_play_clientbound_animation(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, uint8_t)) {
+        void (*f)(bot_t *, vint32_t, uint8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x0b];
     while(parent->next)
         parent = parent->next;
@@ -347,15 +364,16 @@ void register_play_clientbound_animation(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_player(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, 
-            __uint128_t, 
-            int32_t, 
-            int32_t, 
-            int32_t, 
-            int8_t, 
-            int8_t, 
-            int16_t,
-            metadata_t)) {
+        void (*f)(bot_t *, vint32_t,
+                  __uint128_t,
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  int16_t,
+                  metadata_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x0c];
     while(parent->next)
         parent = parent->next;
@@ -365,7 +383,8 @@ void register_play_clientbound_spawn_player(bot_t *bot,
 }
 
 void register_play_clientbound_collect(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, vint32_t)) {
+                                       void (*f)(bot_t *, vint32_t, vint32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x0d];
     while(parent->next)
         parent = parent->next;
@@ -376,13 +395,14 @@ void register_play_clientbound_collect(bot_t *bot,
 
 void register_play_clientbound_spawn_object(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int32_t,
-            int32_t,
-            int32_t,
-            int8_t,
-            int8_t,
-            data_t)) {
+                  int8_t,
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  data_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x0e];
     while(parent->next)
         parent = parent->next;
@@ -393,17 +413,18 @@ void register_play_clientbound_spawn_object(bot_t *bot,
 
 void register_play_clientbound_spawn_mob(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            uint8_t,
-            int32_t,
-            int32_t,
-            int32_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            int16_t,
-            int16_t,
-            int16_t,
-            metadata_t)) {
+                  uint8_t,
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  int16_t,
+                  int16_t,
+                  int16_t,
+                  metadata_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x0f];
     while(parent->next)
         parent = parent->next;
@@ -413,7 +434,8 @@ void register_play_clientbound_spawn_mob(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_painting(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, char *, position_t, uint8_t)) {
+        void (*f)(bot_t *, vint32_t, char *, position_t, uint8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x10];
     while(parent->next)
         parent = parent->next;
@@ -423,7 +445,8 @@ void register_play_clientbound_spawn_painting(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_xp(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, int32_t, int32_t, int32_t, int16_t)) {
+                                        void (*f)(bot_t *, vint32_t, int32_t, int32_t, int32_t, int16_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x11];
     while(parent->next)
         parent = parent->next;
@@ -433,7 +456,8 @@ void register_play_clientbound_spawn_xp(bot_t *bot,
 }
 
 void register_play_clientbound_entity_velocity(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, int16_t, int16_t, int16_t)) {
+        void (*f)(bot_t *, vint32_t, int16_t, int16_t, int16_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x12];
     while(parent->next)
         parent = parent->next;
@@ -443,7 +467,8 @@ void register_play_clientbound_entity_velocity(bot_t *bot,
 }
 
 void register_play_clientbound_entity_destroy_entities(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, vint32_t)) {
+        void (*f)(bot_t *, vint32_t, vint32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x13];
     while(parent->next)
         parent = parent->next;
@@ -453,7 +478,8 @@ void register_play_clientbound_entity_destroy_entities(bot_t *bot,
 }
 
 void register_play_clientbound_entity(bot_t *bot,
-        void (*f)(bot_t *, vint32_t)) {
+                                      void (*f)(bot_t *, vint32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x14];
     while(parent->next)
         parent = parent->next;
@@ -464,10 +490,11 @@ void register_play_clientbound_entity(bot_t *bot,
 
 void register_play_clientbound_entity_move(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            bool)) {
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  bool))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x15];
     while(parent->next)
         parent = parent->next;
@@ -478,10 +505,11 @@ void register_play_clientbound_entity_move(bot_t *bot,
 
 void register_play_clientbound_entity_look(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            bool,
-            int8_t)) {
+                  int8_t,
+                  int8_t,
+                  bool,
+                  int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x16];
     while(parent->next)
         parent = parent->next;
@@ -492,12 +520,13 @@ void register_play_clientbound_entity_look(bot_t *bot,
 
 void register_play_clientbound_entity_look_move(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            bool)) {
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  bool))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x17];
     while(parent->next)
         parent = parent->next;
@@ -508,12 +537,13 @@ void register_play_clientbound_entity_look_move(bot_t *bot,
 
 void register_play_clientbound_entity_teleport(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int32_t,
-            int32_t,
-            int32_t,
-            int8_t,
-            int8_t,
-            bool)) {
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  bool))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x18];
     while(parent->next)
         parent = parent->next;
@@ -523,7 +553,8 @@ void register_play_clientbound_entity_teleport(bot_t *bot,
 }
 
 void register_play_clientbound_entity_head_look(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, int8_t)) {
+        void (*f)(bot_t *, vint32_t, int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x19];
     while(parent->next)
         parent = parent->next;
@@ -533,7 +564,8 @@ void register_play_clientbound_entity_head_look(bot_t *bot,
 }
 
 void register_play_clientbound_entity_status(bot_t *bot,
-        void (*f)(bot_t *, int32_t, int8_t)) {
+        void (*f)(bot_t *, int32_t, int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x1a];
     while(parent->next)
         parent = parent->next;
@@ -543,7 +575,8 @@ void register_play_clientbound_entity_status(bot_t *bot,
 }
 
 void register_play_clientbound_entity_attach(bot_t *bot,
-        void (*f)(bot_t *, int32_t, int32_t, bool)) {
+        void (*f)(bot_t *, int32_t, int32_t, bool))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x1b];
     while(parent->next)
         parent = parent->next;
@@ -554,10 +587,11 @@ void register_play_clientbound_entity_attach(bot_t *bot,
 
 void register_play_clientbound_entity_effect(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            vint32_t,
-            bool)) {
+                  int8_t,
+                  int8_t,
+                  vint32_t,
+                  bool))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x1d];
     while(parent->next)
         parent = parent->next;
@@ -567,7 +601,8 @@ void register_play_clientbound_entity_effect(bot_t *bot,
 }
 
 void register_play_clientbound_entity_clear_effect(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, int8_t)) {
+        void (*f)(bot_t *, vint32_t, int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x1e];
     while(parent->next)
         parent = parent->next;
@@ -577,7 +612,8 @@ void register_play_clientbound_entity_clear_effect(bot_t *bot,
 }
 
 void register_play_clientbound_set_xp(bot_t *bot,
-        void (*f)(bot_t *, float, int32_t, int32_t)) {
+                                      void (*f)(bot_t *, float, int32_t, int32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x1f];
     while(parent->next)
         parent = parent->next;
@@ -588,8 +624,9 @@ void register_play_clientbound_set_xp(bot_t *bot,
 
 void register_play_clientbound_entity_properties(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int32_t,
-            property_t *)) {
+                  int32_t,
+                  property_t *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x20];
     while(parent->next)
         parent = parent->next;
@@ -600,11 +637,12 @@ void register_play_clientbound_entity_properties(bot_t *bot,
 
 void register_play_clientbound_chunk_data(bot_t *bot,
         void (*f)(bot_t *, int32_t,
-            int32_t,
-            bool,
-            uint16_t,
-            vint32_t,
-            int8_t *)) {
+                  int32_t,
+                  bool,
+                  uint16_t,
+                  vint32_t,
+                  int8_t *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x21];
     while(parent->next)
         parent = parent->next;
@@ -614,7 +652,8 @@ void register_play_clientbound_chunk_data(bot_t *bot,
 }
 
 void register_play_clientbound_multi_block_change(bot_t *bot,
-        void (*f)(bot_t *, int32_t, int32_t, vint32_t, record_t *)) {
+        void (*f)(bot_t *, int32_t, int32_t, vint32_t, record_t *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x22];
     while(parent->next)
         parent = parent->next;
@@ -624,7 +663,8 @@ void register_play_clientbound_multi_block_change(bot_t *bot,
 }
 
 void register_play_clientbound_block_change(bot_t *bot,
-        void (*f)(bot_t *, position_t, vint32_t)) {
+        void (*f)(bot_t *, position_t, vint32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x23];
     while(parent->next)
         parent = parent->next;
@@ -634,7 +674,8 @@ void register_play_clientbound_block_change(bot_t *bot,
 }
 
 void register_play_clientbound_block_action(bot_t *bot,
-        void (*f)(bot_t *, position_t, uint8_t, uint8_t, vint32_t)) {
+        void (*f)(bot_t *, position_t, uint8_t, uint8_t, vint32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x24];
     while(parent->next)
         parent = parent->next;
@@ -644,7 +685,8 @@ void register_play_clientbound_block_action(bot_t *bot,
 }
 
 void register_play_clientbound_block_break_animation(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, position_t, int8_t)) {
+        void (*f)(bot_t *, vint32_t, position_t, int8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x25];
     while(parent->next)
         parent = parent->next;
@@ -655,11 +697,12 @@ void register_play_clientbound_block_break_animation(bot_t *bot,
 
 void register_play_clientbound_chunk_bulk(bot_t *bot,
         void (*f)(bot_t *, bool,
-            vint32_t,
-            int32_t,
-            int32_t,
-            uint16_t,
-            int8_t *)) {
+                  vint32_t,
+                  int32_t,
+                  int32_t,
+                  uint16_t,
+                  int8_t *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x26];
     while(parent->next)
         parent = parent->next;
@@ -670,14 +713,15 @@ void register_play_clientbound_chunk_bulk(bot_t *bot,
 
 void register_play_clientbound_explosion(bot_t *bot,
         void (*f)(bot_t *, float,
-            float,
-            float,
-            float,
-            int32_t,
-            record_t *,
-            float,
-            float,
-            float)) {
+                  float,
+                  float,
+                  float,
+                  int32_t,
+                  record_t *,
+                  float,
+                  float,
+                  float))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x27];
     while(parent->next)
         parent = parent->next;
@@ -687,7 +731,8 @@ void register_play_clientbound_explosion(bot_t *bot,
 }
 
 void register_play_clientbound_effect(bot_t *bot,
-        void (*f)(bot_t *, int32_t, position_t, int32_t, bool)) {
+                                      void (*f)(bot_t *, int32_t, position_t, int32_t, bool))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x28];
     while(parent->next)
         parent = parent->next;
@@ -698,11 +743,12 @@ void register_play_clientbound_effect(bot_t *bot,
 
 void register_play_clientbound_sound_effect(bot_t *bot,
         void (*f)(bot_t *, char *,
-            int32_t,
-            int32_t,
-            int32_t,
-            float,
-            uint8_t)) {
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  float,
+                  uint8_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x29];
     while(parent->next)
         parent = parent->next;
@@ -713,10 +759,11 @@ void register_play_clientbound_sound_effect(bot_t *bot,
 
 void register_play_clientbound_entity_spawn_global(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int32_t,
-            int32_t,
-            int32_t)) {
+                  int8_t,
+                  int32_t,
+                  int32_t,
+                  int32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x2c];
     while(parent->next)
         parent = parent->next;
@@ -727,10 +774,11 @@ void register_play_clientbound_entity_spawn_global(bot_t *bot,
 
 void register_play_clientbound_update_sign(bot_t *bot,
         void (*f)(bot_t *, position_t,
-            chat_t,
-            chat_t,
-            chat_t,
-            chat_t)) {
+                  chat_t,
+                  chat_t,
+                  chat_t,
+                  chat_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x33];
     while(parent->next)
         parent = parent->next;
@@ -740,7 +788,8 @@ void register_play_clientbound_update_sign(bot_t *bot,
 }
 
 void register_play_clientbound_plugin_message(bot_t *bot,
-        void (*f)(bot_t *, char *, int8_t *)) {
+        void (*f)(bot_t *, char *, int8_t *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x3f];
     while(parent->next)
         parent = parent->next;
@@ -750,7 +799,8 @@ void register_play_clientbound_plugin_message(bot_t *bot,
 }
 
 void register_play_clientbound_plugin_disconnect(bot_t *bot,
-        void (*f)(bot_t *, char *)) {
+        void (*f)(bot_t *, char *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x40];
     while(parent->next)
         parent = parent->next;
@@ -760,7 +810,8 @@ void register_play_clientbound_plugin_disconnect(bot_t *bot,
 }
 
 void register_play_clientbound_plugin_difficulty(bot_t *bot,
-        void (*f)(bot_t *, char *)) {
+        void (*f)(bot_t *, char *))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x41];
     while(parent->next)
         parent = parent->next;
@@ -770,7 +821,8 @@ void register_play_clientbound_plugin_difficulty(bot_t *bot,
 }
 
 void register_play_clientbound_set_compression(bot_t *bot,
-        void (*f)(bot_t *, vint32_t)) {
+        void (*f)(bot_t *, vint32_t))
+{
     function *parent = &bot->_data->callbacks[PLAY][0x46];
     while(parent->next)
         parent = parent->next;

--- a/src/api.c
+++ b/src/api.c
@@ -174,10 +174,9 @@ void set_pos(bot_t *bot, double x, double y, double z)
     send_play_serverbound_player_move(bot, x, y, z, true);
 }
 
-/* Functions to register callback handlers */
 
 void register_login_clientbound_disconnect(bot_t *bot, 
-        void (*f)(char *)){
+        void (*f)(bot_t *, char *)){
     function *parent = &bot->_data->callbacks[LOGIN][0x00];
     while(parent->next)
         parent = parent->next;
@@ -187,7 +186,7 @@ void register_login_clientbound_disconnect(bot_t *bot,
 }
 
 void register_login_clientbound_success(bot_t *bot,
-        void (*f)(char *, char *)) {
+        void (*f)(bot_t *, char *, char *)) {
 
     function *parent = &bot->_data->callbacks[LOGIN][0x02];
     while(parent->next)
@@ -198,7 +197,7 @@ void register_login_clientbound_success(bot_t *bot,
 }
 
 void register_login_clientbound_set_compression(bot_t *bot,
-        void (*f)(vint32_t)) {
+        void (*f)(bot_t *, vint32_t)) {
     function *parent = &bot->_data->callbacks[LOGIN][0x03];
     while(parent->next)
         parent = parent->next;
@@ -208,7 +207,7 @@ void register_login_clientbound_set_compression(bot_t *bot,
 }
 
 void register_status_clientbound_response(bot_t *bot,
-        void (*f)(char *)) {
+        void (*f)(bot_t *, char *)) {
     function *parent = &bot->_data->callbacks[STATUS][0x00];
     while(parent->next)
         parent = parent->next;
@@ -218,7 +217,7 @@ void register_status_clientbound_response(bot_t *bot,
 }
 
 void register_status_clientbound_ping(bot_t *bot,
-        void (*f)(int64_t)) {
+        void (*f)(bot_t *, int64_t)) {
     function *parent = &bot->_data->callbacks[STATUS][0x01];
     while(parent->next)
         parent = parent->next;
@@ -228,7 +227,7 @@ void register_status_clientbound_ping(bot_t *bot,
 }
 
 void register_play_clientbound_keepalive(bot_t *bot,
-        void (*f)(vint32_t)) {
+        void (*f)(bot_t *, vint32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x00];
     while(parent->next)
         parent = parent->next;
@@ -238,7 +237,7 @@ void register_play_clientbound_keepalive(bot_t *bot,
 }
 
 void register_play_clientbound_join_game(bot_t *bot,
-        void (*f)(int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *)) {
+        void (*f)(bot_t *, int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *)) {
     function *parent = &bot->_data->callbacks[PLAY][0x01];
     while(parent->next)
         parent = parent->next;
@@ -248,7 +247,7 @@ void register_play_clientbound_join_game(bot_t *bot,
 }
 
 void register_play_clientbound_chat(bot_t *bot,
-        void (*f)(char *, int8_t)) {
+        void (*f)(bot_t *, char *, int8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x02];
     while(parent->next)
         parent = parent->next;
@@ -258,7 +257,7 @@ void register_play_clientbound_chat(bot_t *bot,
 }
 
 void register_play_clientbound_time_update(bot_t *bot,
-        void (*f)(int64_t, int64_t)) {
+        void (*f)(bot_t *, int64_t, int64_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x03];
     while(parent->next)
         parent = parent->next;
@@ -268,7 +267,7 @@ void register_play_clientbound_time_update(bot_t *bot,
 }
 
 void register_play_clientbound_entity_equipment(bot_t *bot,
-        void (*f)(vint32_t, int16_t, slot_t)) {
+        void (*f)(bot_t *, vint32_t, int16_t, slot_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x04];
     while(parent->next)
         parent = parent->next;
@@ -278,7 +277,7 @@ void register_play_clientbound_entity_equipment(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_position(bot_t *bot,
-        void (*f)(position_t)) {
+        void (*f)(bot_t *, position_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x05];
     while(parent->next)
         parent = parent->next;
@@ -288,7 +287,7 @@ void register_play_clientbound_spawn_position(bot_t *bot,
 }
 
 void register_play_clientbound_update_health(bot_t *bot,
-        void (*f)(float, vint32_t, float)) {
+        void (*f)(bot_t *, float, vint32_t, float)) {
     function *parent = &bot->_data->callbacks[PLAY][0x06];
     while(parent->next)
         parent = parent->next;
@@ -298,7 +297,7 @@ void register_play_clientbound_update_health(bot_t *bot,
 }
 
 void register_play_clientbound_respawn(bot_t *bot,
-        void (*f)(int32_t, uint8_t, uint8_t, char *)) {
+        void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *)) {
     function *parent = &bot->_data->callbacks[PLAY][0x07];
     while(parent->next)
         parent = parent->next;
@@ -308,7 +307,7 @@ void register_play_clientbound_respawn(bot_t *bot,
 }
 
 void register_play_clientbound_position(bot_t *bot,
-        void (*f)(double, double, double, float, float, int8_t)) {
+        void (*f)(bot_t *, double, double, double, float, float, int8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x08];
     while(parent->next)
         parent = parent->next;
@@ -318,7 +317,7 @@ void register_play_clientbound_position(bot_t *bot,
 }
 
 void register_play_clientbound_item_change(bot_t *bot,
-        void (*f)(int8_t)) {
+        void (*f)(bot_t *, int8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x09];
     while(parent->next)
         parent = parent->next;
@@ -328,7 +327,7 @@ void register_play_clientbound_item_change(bot_t *bot,
 }
 
 void register_play_clientbound_use_bed(bot_t *bot,
-        void (*f)(vint32_t, position_t)) {
+        void (*f)(bot_t *, vint32_t, position_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x0a];
     while(parent->next)
         parent = parent->next;
@@ -338,7 +337,7 @@ void register_play_clientbound_use_bed(bot_t *bot,
 }
 
 void register_play_clientbound_animation(bot_t *bot,
-        void (*f)(vint32_t, uint8_t)) {
+        void (*f)(bot_t *, vint32_t, uint8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x0b];
     while(parent->next)
         parent = parent->next;
@@ -348,7 +347,7 @@ void register_play_clientbound_animation(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_player(bot_t *bot,
-        void (*f)(vint32_t, 
+        void (*f)(bot_t *, vint32_t, 
             __uint128_t, 
             int32_t, 
             int32_t, 
@@ -366,7 +365,7 @@ void register_play_clientbound_spawn_player(bot_t *bot,
 }
 
 void register_play_clientbound_collect(bot_t *bot,
-        void (*f)(vint32_t, vint32_t)) {
+        void (*f)(bot_t *, vint32_t, vint32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x0d];
     while(parent->next)
         parent = parent->next;
@@ -376,7 +375,7 @@ void register_play_clientbound_collect(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_object(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int32_t,
             int32_t,
@@ -393,7 +392,7 @@ void register_play_clientbound_spawn_object(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_mob(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             uint8_t,
             int32_t,
             int32_t,
@@ -414,7 +413,7 @@ void register_play_clientbound_spawn_mob(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_painting(bot_t *bot,
-        void (*f)(vint32_t, char *, position_t, uint8_t)) {
+        void (*f)(bot_t *, vint32_t, char *, position_t, uint8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x10];
     while(parent->next)
         parent = parent->next;
@@ -424,7 +423,7 @@ void register_play_clientbound_spawn_painting(bot_t *bot,
 }
 
 void register_play_clientbound_spawn_xp(bot_t *bot,
-        void (*f)(vint32_t, int32_t, int32_t, int32_t, int16_t)) {
+        void (*f)(bot_t *, vint32_t, int32_t, int32_t, int32_t, int16_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x11];
     while(parent->next)
         parent = parent->next;
@@ -434,7 +433,7 @@ void register_play_clientbound_spawn_xp(bot_t *bot,
 }
 
 void register_play_clientbound_entity_velocity(bot_t *bot,
-        void (*f)(vint32_t, int16_t, int16_t, int16_t)) {
+        void (*f)(bot_t *, vint32_t, int16_t, int16_t, int16_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x12];
     while(parent->next)
         parent = parent->next;
@@ -444,7 +443,7 @@ void register_play_clientbound_entity_velocity(bot_t *bot,
 }
 
 void register_play_clientbound_entity_destroy_entities(bot_t *bot,
-        void (*f)(vint32_t, vint32_t)) {
+        void (*f)(bot_t *, vint32_t, vint32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x13];
     while(parent->next)
         parent = parent->next;
@@ -454,7 +453,7 @@ void register_play_clientbound_entity_destroy_entities(bot_t *bot,
 }
 
 void register_play_clientbound_entity(bot_t *bot,
-        void (*f)(vint32_t)) {
+        void (*f)(bot_t *, vint32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x14];
     while(parent->next)
         parent = parent->next;
@@ -464,7 +463,7 @@ void register_play_clientbound_entity(bot_t *bot,
 }
 
 void register_play_clientbound_entity_move(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             int8_t,
@@ -478,7 +477,7 @@ void register_play_clientbound_entity_move(bot_t *bot,
 }
 
 void register_play_clientbound_entity_look(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             bool,
@@ -492,7 +491,7 @@ void register_play_clientbound_entity_look(bot_t *bot,
 }
 
 void register_play_clientbound_entity_look_move(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             int8_t,
@@ -508,7 +507,7 @@ void register_play_clientbound_entity_look_move(bot_t *bot,
 }
 
 void register_play_clientbound_entity_teleport(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int32_t,
             int32_t,
             int32_t,
@@ -524,7 +523,7 @@ void register_play_clientbound_entity_teleport(bot_t *bot,
 }
 
 void register_play_clientbound_entity_head_look(bot_t *bot,
-        void (*f)(vint32_t, int8_t)) {
+        void (*f)(bot_t *, vint32_t, int8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x19];
     while(parent->next)
         parent = parent->next;
@@ -534,7 +533,7 @@ void register_play_clientbound_entity_head_look(bot_t *bot,
 }
 
 void register_play_clientbound_entity_status(bot_t *bot,
-        void (*f)(int32_t, int8_t)) {
+        void (*f)(bot_t *, int32_t, int8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x1a];
     while(parent->next)
         parent = parent->next;
@@ -544,7 +543,7 @@ void register_play_clientbound_entity_status(bot_t *bot,
 }
 
 void register_play_clientbound_entity_attach(bot_t *bot,
-        void (*f)(int32_t, int32_t, bool)) {
+        void (*f)(bot_t *, int32_t, int32_t, bool)) {
     function *parent = &bot->_data->callbacks[PLAY][0x1b];
     while(parent->next)
         parent = parent->next;
@@ -554,7 +553,7 @@ void register_play_clientbound_entity_attach(bot_t *bot,
 }
 
 void register_play_clientbound_entity_effect(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             vint32_t,
@@ -568,7 +567,7 @@ void register_play_clientbound_entity_effect(bot_t *bot,
 }
 
 void register_play_clientbound_entity_clear_effect(bot_t *bot,
-        void (*f)(vint32_t, int8_t)) {
+        void (*f)(bot_t *, vint32_t, int8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x1e];
     while(parent->next)
         parent = parent->next;
@@ -578,7 +577,7 @@ void register_play_clientbound_entity_clear_effect(bot_t *bot,
 }
 
 void register_play_clientbound_set_xp(bot_t *bot,
-        void (*f)(float, int32_t, int32_t)) {
+        void (*f)(bot_t *, float, int32_t, int32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x1f];
     while(parent->next)
         parent = parent->next;
@@ -588,7 +587,7 @@ void register_play_clientbound_set_xp(bot_t *bot,
 }
 
 void register_play_clientbound_entity_properties(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int32_t,
             property_t *)) {
     function *parent = &bot->_data->callbacks[PLAY][0x20];
@@ -600,7 +599,7 @@ void register_play_clientbound_entity_properties(bot_t *bot,
 }
 
 void register_play_clientbound_chunk_data(bot_t *bot,
-        void (*f)(int32_t,
+        void (*f)(bot_t *, int32_t,
             int32_t,
             bool,
             uint16_t,
@@ -615,7 +614,7 @@ void register_play_clientbound_chunk_data(bot_t *bot,
 }
 
 void register_play_clientbound_multi_block_change(bot_t *bot,
-        void (*f)(int32_t, int32_t, vint32_t, record_t *)) {
+        void (*f)(bot_t *, int32_t, int32_t, vint32_t, record_t *)) {
     function *parent = &bot->_data->callbacks[PLAY][0x22];
     while(parent->next)
         parent = parent->next;
@@ -625,7 +624,7 @@ void register_play_clientbound_multi_block_change(bot_t *bot,
 }
 
 void register_play_clientbound_block_change(bot_t *bot,
-        void (*f)(position_t, vint32_t)) {
+        void (*f)(bot_t *, position_t, vint32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x23];
     while(parent->next)
         parent = parent->next;
@@ -635,7 +634,7 @@ void register_play_clientbound_block_change(bot_t *bot,
 }
 
 void register_play_clientbound_block_action(bot_t *bot,
-        void (*f)(position_t, uint8_t, uint8_t, vint32_t)) {
+        void (*f)(bot_t *, position_t, uint8_t, uint8_t, vint32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x24];
     while(parent->next)
         parent = parent->next;
@@ -645,7 +644,7 @@ void register_play_clientbound_block_action(bot_t *bot,
 }
 
 void register_play_clientbound_block_break_animation(bot_t *bot,
-        void (*f)(vint32_t, position_t, int8_t)) {
+        void (*f)(bot_t *, vint32_t, position_t, int8_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x25];
     while(parent->next)
         parent = parent->next;
@@ -655,7 +654,7 @@ void register_play_clientbound_block_break_animation(bot_t *bot,
 }
 
 void register_play_clientbound_chunk_bulk(bot_t *bot,
-        void (*f)(bool,
+        void (*f)(bot_t *, bool,
             vint32_t,
             int32_t,
             int32_t,
@@ -670,7 +669,7 @@ void register_play_clientbound_chunk_bulk(bot_t *bot,
 }
 
 void register_play_clientbound_explosion(bot_t *bot,
-        void (*f)(float,
+        void (*f)(bot_t *, float,
             float,
             float,
             float,
@@ -688,7 +687,7 @@ void register_play_clientbound_explosion(bot_t *bot,
 }
 
 void register_play_clientbound_effect(bot_t *bot,
-        void (*f)(int32_t, position_t, int32_t, bool)) {
+        void (*f)(bot_t *, int32_t, position_t, int32_t, bool)) {
     function *parent = &bot->_data->callbacks[PLAY][0x28];
     while(parent->next)
         parent = parent->next;
@@ -698,7 +697,7 @@ void register_play_clientbound_effect(bot_t *bot,
 }
 
 void register_play_clientbound_sound_effect(bot_t *bot,
-        void (*f)(char *,
+        void (*f)(bot_t *, char *,
             int32_t,
             int32_t,
             int32_t,
@@ -713,7 +712,7 @@ void register_play_clientbound_sound_effect(bot_t *bot,
 }
 
 void register_play_clientbound_entity_spawn_global(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int32_t,
             int32_t,
@@ -727,7 +726,7 @@ void register_play_clientbound_entity_spawn_global(bot_t *bot,
 }
 
 void register_play_clientbound_update_sign(bot_t *bot,
-        void (*f)(position_t,
+        void (*f)(bot_t *, position_t,
             chat_t,
             chat_t,
             chat_t,
@@ -741,7 +740,7 @@ void register_play_clientbound_update_sign(bot_t *bot,
 }
 
 void register_play_clientbound_plugin_message(bot_t *bot,
-        void (*f)(char *, int8_t *)) {
+        void (*f)(bot_t *, char *, int8_t *)) {
     function *parent = &bot->_data->callbacks[PLAY][0x3f];
     while(parent->next)
         parent = parent->next;
@@ -751,7 +750,7 @@ void register_play_clientbound_plugin_message(bot_t *bot,
 }
 
 void register_play_clientbound_plugin_disconnect(bot_t *bot,
-        void (*f)(char *)) {
+        void (*f)(bot_t *, char *)) {
     function *parent = &bot->_data->callbacks[PLAY][0x40];
     while(parent->next)
         parent = parent->next;
@@ -761,7 +760,7 @@ void register_play_clientbound_plugin_disconnect(bot_t *bot,
 }
 
 void register_play_clientbound_plugin_difficulty(bot_t *bot,
-        void (*f)(char *)) {
+        void (*f)(bot_t *, char *)) {
     function *parent = &bot->_data->callbacks[PLAY][0x41];
     while(parent->next)
         parent = parent->next;
@@ -771,7 +770,7 @@ void register_play_clientbound_plugin_difficulty(bot_t *bot,
 }
 
 void register_play_clientbound_set_compression(bot_t *bot,
-        void (*f)()) {
+        void (*f)(bot_t *, vint32_t)) {
     function *parent = &bot->_data->callbacks[PLAY][0x46];
     while(parent->next)
         parent = parent->next;

--- a/src/api.h
+++ b/src/api.h
@@ -63,58 +63,58 @@ void set_pos(bot_t *bot, double x, double y, double z);
 /* Register callback handlers */
 
 void register_login_clientbound_disconnect(bot_t *bot, 
-        void (*f)(char *));
+        void (*f)(bot_t *, char *));
 
 void register_login_clientbound_success(bot_t *bot,
-        void (*f)(char *, char *));
+        void (*f)(bot_t *, char *, char *));
 
 void register_login_clientbound_set_compression(bot_t *bot,
-        void (*f)(vint32_t));
+        void (*f)(bot_t *, vint32_t));
 
 void register_status_clientbound_response(bot_t *bot,
-        void (*f)(char *));
+        void (*f)(bot_t *, char *));
 
 void register_status_clientbound_ping(bot_t *bot,
-        void (*f)(int64_t));
+        void (*f)(bot_t *, int64_t));
 
 void register_play_clientbound_keepalive(bot_t *bot,
-        void (*f)(vint32_t));
+        void (*f)(bot_t *, vint32_t));
 
 void register_play_clientbound_join_game(bot_t *bot,
-        void (*f)(int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *));
+        void (*f)(bot_t *, int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *));
 
 void register_play_clientbound_chat(bot_t *bot,
-        void (*f)(char *, int8_t));
+        void (*f)(bot_t *, char *, int8_t));
 
 void register_play_clientbound_time_update(bot_t *bot,
-        void (*f)(int64_t, int64_t));
+        void (*f)(bot_t *, int64_t, int64_t));
 
 void register_play_clientbound_entity_equipment(bot_t *bot,
-        void (*f)(vint32_t, int16_t, slot_t));
+        void (*f)(bot_t *, vint32_t, int16_t, slot_t));
 
 void register_play_clientbound_spawn_position(bot_t *bot,
-        void (*f)(position_t));
+        void (*f)(bot_t *, position_t));
 
 void register_play_clientbound_update_health(bot_t *bot,
-        void (*f)(float, vint32_t, float));
+        void (*f)(bot_t *, float, vint32_t, float));
 
 void register_play_clientbound_respawn(bot_t *bot,
-        void (*f)(int32_t, uint8_t, uint8_t, char *));
+        void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *));
 
 void register_play_clientbound_position(bot_t *bot,
-        void (*f)(double, double, double, float, float, int8_t));
+        void (*f)(bot_t *, double, double, double, float, float, int8_t));
 
 void register_play_clientbound_item_change(bot_t *bot,
-        void (*f)(int8_t));
+        void (*f)(bot_t *, int8_t));
 
 void register_play_clientbound_use_bed(bot_t *bot,
-        void (*f)(vint32_t, position_t));
+        void (*f)(bot_t *, vint32_t, position_t));
 
 void register_play_clientbound_animation(bot_t *bot,
-        void (*f)(vint32_t, uint8_t));
+        void (*f)(bot_t *, vint32_t, uint8_t));
 
 void register_play_clientbound_spawn_player(bot_t *bot,
-        void (*f)(vint32_t, 
+        void (*f)(bot_t *, vint32_t, 
             __uint128_t, 
             int32_t, 
             int32_t, 
@@ -125,10 +125,10 @@ void register_play_clientbound_spawn_player(bot_t *bot,
             metadata_t));
 
 void register_play_clientbound_collect(bot_t *bot,
-        void (*f)(vint32_t, vint32_t));
+        void (*f)(bot_t *, vint32_t, vint32_t));
 
 void register_play_clientbound_spawn_object(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int32_t,
             int32_t,
@@ -138,7 +138,7 @@ void register_play_clientbound_spawn_object(bot_t *bot,
             data_t));
 
 void register_play_clientbound_spawn_mob(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             uint8_t,
             int32_t,
             int32_t,
@@ -152,36 +152,36 @@ void register_play_clientbound_spawn_mob(bot_t *bot,
             metadata_t));
 
 void register_play_clientbound_spawn_painting(bot_t *bot,
-        void (*f)(vint32_t, char *, position_t, uint8_t));
+        void (*f)(bot_t *, vint32_t, char *, position_t, uint8_t));
 
 void register_play_clientbound_spawn_xp(bot_t *bot,
-        void (*f)(vint32_t, int32_t, int32_t, int32_t, int16_t));
+        void (*f)(bot_t *, vint32_t, int32_t, int32_t, int32_t, int16_t));
 
 void register_play_clientbound_entity_velocity(bot_t *bot,
-        void (*f)(vint32_t, int16_t, int16_t, int16_t));
+        void (*f)(bot_t *, vint32_t, int16_t, int16_t, int16_t));
 
 void register_play_clientbound_entity_destroy_entities(bot_t *bot,
-        void (*f)(vint32_t, vint32_t));
+        void (*f)(bot_t *, vint32_t, vint32_t));
 
 void register_play_clientbound_entity(bot_t *bot,
-        void (*f)(vint32_t));
+        void (*f)(bot_t *, vint32_t));
 
 void register_play_clientbound_entity_move(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             int8_t,
             bool));
 
 void register_play_clientbound_entity_look(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             bool,
             int8_t));
 
 void register_play_clientbound_entity_look_move(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             int8_t,
@@ -190,7 +190,7 @@ void register_play_clientbound_entity_look_move(bot_t *bot,
             bool));
 
 void register_play_clientbound_entity_teleport(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int32_t,
             int32_t,
             int32_t,
@@ -199,34 +199,34 @@ void register_play_clientbound_entity_teleport(bot_t *bot,
             bool));
 
 void register_play_clientbound_entity_head_look(bot_t *bot,
-        void (*f)(vint32_t, int8_t));
+        void (*f)(bot_t *, vint32_t, int8_t));
 
 void register_play_clientbound_entity_status(bot_t *bot,
-        void (*f)(int32_t, int8_t));
+        void (*f)(bot_t *, int32_t, int8_t));
 
 void register_play_clientbound_entity_attach(bot_t *bot,
-        void (*f)(int32_t, int32_t, bool));
+        void (*f)(bot_t *, int32_t, int32_t, bool));
 
 void register_play_clientbound_entity_effect(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int8_t,
             vint32_t,
             bool));
 
 void register_play_clientbound_entity_clear_effect(bot_t *bot,
-        void (*f)(vint32_t, int8_t));
+        void (*f)(bot_t *, vint32_t, int8_t));
 
 void register_play_clientbound_set_xp(bot_t *bot,
-        void (*f)(float, int32_t, int32_t));
+        void (*f)(bot_t *, float, int32_t, int32_t));
 
 void register_play_clientbound_entity_properties(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int32_t,
             property_t *));
 
 void register_play_clientbound_chunk_data(bot_t *bot,
-        void (*f)(int32_t,
+        void (*f)(bot_t *, int32_t,
             int32_t,
             bool,
             uint16_t,
@@ -234,19 +234,19 @@ void register_play_clientbound_chunk_data(bot_t *bot,
             int8_t *));
 
 void register_play_clientbound_multi_block_change(bot_t *bot,
-        void (*f)(int32_t, int32_t, vint32_t, record_t *));
+        void (*f)(bot_t *, int32_t, int32_t, vint32_t, record_t *));
 
 void register_play_clientbound_block_change(bot_t *bot,
-        void (*f)(position_t, vint32_t));
+        void (*f)(bot_t *, position_t, vint32_t));
 
 void register_play_clientbound_block_action(bot_t *bot,
-        void (*f)(position_t, uint8_t, uint8_t, vint32_t));
+        void (*f)(bot_t *, position_t, uint8_t, uint8_t, vint32_t));
 
 void register_play_clientbound_block_break_animation(bot_t *bot,
-        void (*f)(vint32_t, position_t, int8_t));
+        void (*f)(bot_t *, vint32_t, position_t, int8_t));
 
 void register_play_clientbound_chunk_bulk(bot_t *bot,
-        void (*f)(bool,
+        void (*f)(bot_t *, bool,
             vint32_t,
             int32_t,
             int32_t,
@@ -254,7 +254,7 @@ void register_play_clientbound_chunk_bulk(bot_t *bot,
             int8_t *));
 
 void register_play_clientbound_explosion(bot_t *bot,
-        void (*f)(float,
+        void (*f)(bot_t *, float,
             float,
             float,
             float,
@@ -265,10 +265,10 @@ void register_play_clientbound_explosion(bot_t *bot,
             float));
 
 void register_play_clientbound_effect(bot_t *bot,
-        void (*f)(int32_t, position_t, int32_t, bool));
+        void (*f)(bot_t *, int32_t, position_t, int32_t, bool));
 
 void register_play_clientbound_sound_effect(bot_t *bot,
-        void (*f)(char *,
+        void (*f)(bot_t *, char *,
             int32_t,
             int32_t,
             int32_t,
@@ -276,27 +276,27 @@ void register_play_clientbound_sound_effect(bot_t *bot,
             uint8_t));
 
 void register_play_clientbound_entity_spawn_global(bot_t *bot,
-        void (*f)(vint32_t,
+        void (*f)(bot_t *, vint32_t,
             int8_t,
             int32_t,
             int32_t,
             int32_t));
 
 void register_play_clientbound_update_sign(bot_t *bot,
-        void (*f)(position_t,
+        void (*f)(bot_t *, position_t,
             chat_t,
             chat_t,
             chat_t,
             chat_t));
 
 void register_play_clientbound_plugin_message(bot_t *bot,
-        void (*f)(char *, int8_t *));
+        void (*f)(bot_t *, char *, int8_t *));
 
 void register_play_clientbound_plugin_disconnect(bot_t *bot,
-        void (*f)(char *));
+        void (*f)(bot_t *, char *));
 
 void register_play_clientbound_plugin_difficulty(bot_t *bot,
-        void (*f)(char *));
+        void (*f)(bot_t *, char *));
 
 void register_play_clientbound_set_compression(bot_t *bot,
-        void (*f)());
+        void (*f)(bot_t *, vint32_t));

--- a/src/api.h
+++ b/src/api.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bot.h"
+#include "types.h"
 
 /* Briefly suspend thread execution for an interval measured in ms
  *

--- a/src/api.h
+++ b/src/api.h
@@ -63,11 +63,11 @@ void set_pos(bot_t *bot, double x, double y, double z);
 
 /* Register callback handlers */
 
-void register_login_clientbound_disconnect(bot_t *bot, 
+void register_login_clientbound_disconnect(bot_t *bot,
         void (*f)(bot_t *, char *));
 
 void register_login_clientbound_success(bot_t *bot,
-        void (*f)(bot_t *, char *, char *));
+                                        void (*f)(bot_t *, char *, char *));
 
 void register_login_clientbound_set_compression(bot_t *bot,
         void (*f)(bot_t *, vint32_t));
@@ -76,7 +76,7 @@ void register_status_clientbound_response(bot_t *bot,
         void (*f)(bot_t *, char *));
 
 void register_status_clientbound_ping(bot_t *bot,
-        void (*f)(bot_t *, int64_t));
+                                      void (*f)(bot_t *, int64_t));
 
 void register_play_clientbound_keepalive(bot_t *bot,
         void (*f)(bot_t *, vint32_t));
@@ -85,7 +85,7 @@ void register_play_clientbound_join_game(bot_t *bot,
         void (*f)(bot_t *, int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *));
 
 void register_play_clientbound_chat(bot_t *bot,
-        void (*f)(bot_t *, char *, int8_t));
+                                    void (*f)(bot_t *, char *, int8_t));
 
 void register_play_clientbound_time_update(bot_t *bot,
         void (*f)(bot_t *, int64_t, int64_t));
@@ -100,63 +100,63 @@ void register_play_clientbound_update_health(bot_t *bot,
         void (*f)(bot_t *, float, vint32_t, float));
 
 void register_play_clientbound_respawn(bot_t *bot,
-        void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *));
+                                       void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *));
 
 void register_play_clientbound_position(bot_t *bot,
-        void (*f)(bot_t *, double, double, double, float, float, int8_t));
+                                        void (*f)(bot_t *, double, double, double, float, float, int8_t));
 
 void register_play_clientbound_item_change(bot_t *bot,
         void (*f)(bot_t *, int8_t));
 
 void register_play_clientbound_use_bed(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, position_t));
+                                       void (*f)(bot_t *, vint32_t, position_t));
 
 void register_play_clientbound_animation(bot_t *bot,
         void (*f)(bot_t *, vint32_t, uint8_t));
 
 void register_play_clientbound_spawn_player(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, 
-            __uint128_t, 
-            int32_t, 
-            int32_t, 
-            int32_t, 
-            int8_t, 
-            int8_t, 
-            int16_t,
-            metadata_t));
+        void (*f)(bot_t *, vint32_t,
+                  __uint128_t,
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  int16_t,
+                  metadata_t));
 
 void register_play_clientbound_collect(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, vint32_t));
+                                       void (*f)(bot_t *, vint32_t, vint32_t));
 
 void register_play_clientbound_spawn_object(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int32_t,
-            int32_t,
-            int32_t,
-            int8_t,
-            int8_t,
-            data_t));
+                  int8_t,
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  data_t));
 
 void register_play_clientbound_spawn_mob(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            uint8_t,
-            int32_t,
-            int32_t,
-            int32_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            int16_t,
-            int16_t,
-            int16_t,
-            metadata_t));
+                  uint8_t,
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  int16_t,
+                  int16_t,
+                  int16_t,
+                  metadata_t));
 
 void register_play_clientbound_spawn_painting(bot_t *bot,
         void (*f)(bot_t *, vint32_t, char *, position_t, uint8_t));
 
 void register_play_clientbound_spawn_xp(bot_t *bot,
-        void (*f)(bot_t *, vint32_t, int32_t, int32_t, int32_t, int16_t));
+                                        void (*f)(bot_t *, vint32_t, int32_t, int32_t, int32_t, int16_t));
 
 void register_play_clientbound_entity_velocity(bot_t *bot,
         void (*f)(bot_t *, vint32_t, int16_t, int16_t, int16_t));
@@ -165,39 +165,39 @@ void register_play_clientbound_entity_destroy_entities(bot_t *bot,
         void (*f)(bot_t *, vint32_t, vint32_t));
 
 void register_play_clientbound_entity(bot_t *bot,
-        void (*f)(bot_t *, vint32_t));
+                                      void (*f)(bot_t *, vint32_t));
 
 void register_play_clientbound_entity_move(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            bool));
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  bool));
 
 void register_play_clientbound_entity_look(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            bool,
-            int8_t));
+                  int8_t,
+                  int8_t,
+                  bool,
+                  int8_t));
 
 void register_play_clientbound_entity_look_move(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            int8_t,
-            bool));
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  int8_t,
+                  bool));
 
 void register_play_clientbound_entity_teleport(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int32_t,
-            int32_t,
-            int32_t,
-            int8_t,
-            int8_t,
-            bool));
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  int8_t,
+                  int8_t,
+                  bool));
 
 void register_play_clientbound_entity_head_look(bot_t *bot,
         void (*f)(bot_t *, vint32_t, int8_t));
@@ -210,29 +210,29 @@ void register_play_clientbound_entity_attach(bot_t *bot,
 
 void register_play_clientbound_entity_effect(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int8_t,
-            vint32_t,
-            bool));
+                  int8_t,
+                  int8_t,
+                  vint32_t,
+                  bool));
 
 void register_play_clientbound_entity_clear_effect(bot_t *bot,
         void (*f)(bot_t *, vint32_t, int8_t));
 
 void register_play_clientbound_set_xp(bot_t *bot,
-        void (*f)(bot_t *, float, int32_t, int32_t));
+                                      void (*f)(bot_t *, float, int32_t, int32_t));
 
 void register_play_clientbound_entity_properties(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int32_t,
-            property_t *));
+                  int32_t,
+                  property_t *));
 
 void register_play_clientbound_chunk_data(bot_t *bot,
         void (*f)(bot_t *, int32_t,
-            int32_t,
-            bool,
-            uint16_t,
-            vint32_t,
-            int8_t *));
+                  int32_t,
+                  bool,
+                  uint16_t,
+                  vint32_t,
+                  int8_t *));
 
 void register_play_clientbound_multi_block_change(bot_t *bot,
         void (*f)(bot_t *, int32_t, int32_t, vint32_t, record_t *));
@@ -248,47 +248,47 @@ void register_play_clientbound_block_break_animation(bot_t *bot,
 
 void register_play_clientbound_chunk_bulk(bot_t *bot,
         void (*f)(bot_t *, bool,
-            vint32_t,
-            int32_t,
-            int32_t,
-            uint16_t,
-            int8_t *));
+                  vint32_t,
+                  int32_t,
+                  int32_t,
+                  uint16_t,
+                  int8_t *));
 
 void register_play_clientbound_explosion(bot_t *bot,
         void (*f)(bot_t *, float,
-            float,
-            float,
-            float,
-            int32_t,
-            record_t *,
-            float,
-            float,
-            float));
+                  float,
+                  float,
+                  float,
+                  int32_t,
+                  record_t *,
+                  float,
+                  float,
+                  float));
 
 void register_play_clientbound_effect(bot_t *bot,
-        void (*f)(bot_t *, int32_t, position_t, int32_t, bool));
+                                      void (*f)(bot_t *, int32_t, position_t, int32_t, bool));
 
 void register_play_clientbound_sound_effect(bot_t *bot,
         void (*f)(bot_t *, char *,
-            int32_t,
-            int32_t,
-            int32_t,
-            float,
-            uint8_t));
+                  int32_t,
+                  int32_t,
+                  int32_t,
+                  float,
+                  uint8_t));
 
 void register_play_clientbound_entity_spawn_global(bot_t *bot,
         void (*f)(bot_t *, vint32_t,
-            int8_t,
-            int32_t,
-            int32_t,
-            int32_t));
+                  int8_t,
+                  int32_t,
+                  int32_t,
+                  int32_t));
 
 void register_play_clientbound_update_sign(bot_t *bot,
         void (*f)(bot_t *, position_t,
-            chat_t,
-            chat_t,
-            chat_t,
-            chat_t));
+                  chat_t,
+                  chat_t,
+                  chat_t,
+                  chat_t));
 
 void register_play_clientbound_plugin_message(bot_t *bot,
         void (*f)(bot_t *, char *, int8_t *));

--- a/src/api.h
+++ b/src/api.h
@@ -59,3 +59,244 @@ void decode_chat_json(char *raw_json, char **msg, char **sender_name);
  * This is the correct way to set the bot's position.
  */
 void set_pos(bot_t *bot, double x, double y, double z);
+
+/* Register callback handlers */
+
+void register_login_clientbound_disconnect(bot_t *bot, 
+        void (*f)(char *));
+
+void register_login_clientbound_success(bot_t *bot,
+        void (*f)(char *, char *));
+
+void register_login_clientbound_set_compression(bot_t *bot,
+        void (*f)(vint32_t));
+
+void register_status_clientbound_response(bot_t *bot,
+        void (*f)(char *));
+
+void register_status_clientbound_ping(bot_t *bot,
+        void (*f)(int64_t));
+
+void register_play_clientbound_keepalive(bot_t *bot,
+        void (*f)(vint32_t));
+
+void register_play_clientbound_join_game(bot_t *bot,
+        void (*f)(int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *));
+
+void register_play_clientbound_chat(bot_t *bot,
+        void (*f)(char *, int8_t));
+
+void register_play_clientbound_time_update(bot_t *bot,
+        void (*f)(int64_t, int64_t));
+
+void register_play_clientbound_entity_equipment(bot_t *bot,
+        void (*f)(vint32_t, int16_t, slot_t));
+
+void register_play_clientbound_spawn_position(bot_t *bot,
+        void (*f)(position_t));
+
+void register_play_clientbound_update_health(bot_t *bot,
+        void (*f)(float, vint32_t, float));
+
+void register_play_clientbound_respawn(bot_t *bot,
+        void (*f)(int32_t, uint8_t, uint8_t, char *));
+
+void register_play_clientbound_position(bot_t *bot,
+        void (*f)(double, double, double, float, float, int8_t));
+
+void register_play_clientbound_item_change(bot_t *bot,
+        void (*f)(int8_t));
+
+void register_play_clientbound_use_bed(bot_t *bot,
+        void (*f)(vint32_t, position_t));
+
+void register_play_clientbound_animation(bot_t *bot,
+        void (*f)(vint32_t, uint8_t));
+
+void register_play_clientbound_spawn_player(bot_t *bot,
+        void (*f)(vint32_t, 
+            __uint128_t, 
+            int32_t, 
+            int32_t, 
+            int32_t, 
+            int8_t, 
+            int8_t, 
+            int16_t,
+            metadata_t));
+
+void register_play_clientbound_collect(bot_t *bot,
+        void (*f)(vint32_t, vint32_t));
+
+void register_play_clientbound_spawn_object(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int32_t,
+            int32_t,
+            int32_t,
+            int8_t,
+            int8_t,
+            data_t));
+
+void register_play_clientbound_spawn_mob(bot_t *bot,
+        void (*f)(vint32_t,
+            uint8_t,
+            int32_t,
+            int32_t,
+            int32_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            int16_t,
+            int16_t,
+            int16_t,
+            metadata_t));
+
+void register_play_clientbound_spawn_painting(bot_t *bot,
+        void (*f)(vint32_t, char *, position_t, uint8_t));
+
+void register_play_clientbound_spawn_xp(bot_t *bot,
+        void (*f)(vint32_t, int32_t, int32_t, int32_t, int16_t));
+
+void register_play_clientbound_entity_velocity(bot_t *bot,
+        void (*f)(vint32_t, int16_t, int16_t, int16_t));
+
+void register_play_clientbound_entity_destroy_entities(bot_t *bot,
+        void (*f)(vint32_t, vint32_t));
+
+void register_play_clientbound_entity(bot_t *bot,
+        void (*f)(vint32_t));
+
+void register_play_clientbound_entity_move(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            bool));
+
+void register_play_clientbound_entity_look(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            bool,
+            int8_t));
+
+void register_play_clientbound_entity_look_move(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            int8_t,
+            bool));
+
+void register_play_clientbound_entity_teleport(bot_t *bot,
+        void (*f)(vint32_t,
+            int32_t,
+            int32_t,
+            int32_t,
+            int8_t,
+            int8_t,
+            bool));
+
+void register_play_clientbound_entity_head_look(bot_t *bot,
+        void (*f)(vint32_t, int8_t));
+
+void register_play_clientbound_entity_status(bot_t *bot,
+        void (*f)(int32_t, int8_t));
+
+void register_play_clientbound_entity_attach(bot_t *bot,
+        void (*f)(int32_t, int32_t, bool));
+
+void register_play_clientbound_entity_effect(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int8_t,
+            vint32_t,
+            bool));
+
+void register_play_clientbound_entity_clear_effect(bot_t *bot,
+        void (*f)(vint32_t, int8_t));
+
+void register_play_clientbound_set_xp(bot_t *bot,
+        void (*f)(float, int32_t, int32_t));
+
+void register_play_clientbound_entity_properties(bot_t *bot,
+        void (*f)(vint32_t,
+            int32_t,
+            property_t *));
+
+void register_play_clientbound_chunk_data(bot_t *bot,
+        void (*f)(int32_t,
+            int32_t,
+            bool,
+            uint16_t,
+            vint32_t,
+            int8_t *));
+
+void register_play_clientbound_multi_block_change(bot_t *bot,
+        void (*f)(int32_t, int32_t, vint32_t, record_t *));
+
+void register_play_clientbound_block_change(bot_t *bot,
+        void (*f)(position_t, vint32_t));
+
+void register_play_clientbound_block_action(bot_t *bot,
+        void (*f)(position_t, uint8_t, uint8_t, vint32_t));
+
+void register_play_clientbound_block_break_animation(bot_t *bot,
+        void (*f)(vint32_t, position_t, int8_t));
+
+void register_play_clientbound_chunk_bulk(bot_t *bot,
+        void (*f)(bool,
+            vint32_t,
+            int32_t,
+            int32_t,
+            uint16_t,
+            int8_t *));
+
+void register_play_clientbound_explosion(bot_t *bot,
+        void (*f)(float,
+            float,
+            float,
+            float,
+            int32_t,
+            record_t *,
+            float,
+            float,
+            float));
+
+void register_play_clientbound_effect(bot_t *bot,
+        void (*f)(int32_t, position_t, int32_t, bool));
+
+void register_play_clientbound_sound_effect(bot_t *bot,
+        void (*f)(char *,
+            int32_t,
+            int32_t,
+            int32_t,
+            float,
+            uint8_t));
+
+void register_play_clientbound_entity_spawn_global(bot_t *bot,
+        void (*f)(vint32_t,
+            int8_t,
+            int32_t,
+            int32_t,
+            int32_t));
+
+void register_play_clientbound_update_sign(bot_t *bot,
+        void (*f)(position_t,
+            chat_t,
+            chat_t,
+            chat_t,
+            chat_t));
+
+void register_play_clientbound_plugin_message(bot_t *bot,
+        void (*f)(char *, int8_t *));
+
+void register_play_clientbound_plugin_disconnect(bot_t *bot,
+        void (*f)(char *));
+
+void register_play_clientbound_plugin_difficulty(bot_t *bot,
+        void (*f)(char *));
+
+void register_play_clientbound_set_compression(bot_t *bot,
+        void (*f)());

--- a/src/bot.c
+++ b/src/bot.c
@@ -89,17 +89,6 @@ void free_list(function *list)
     }
 }
 
-void register_event(bot_t *bot, uint32_t state, uint32_t packet_id,
-                    void (*f)(bot_t *, void *))
-{
-    function *parent = &bot->_data->callbacks[state][packet_id];
-    while(parent->next)
-        parent = parent->next;
-    function *child = calloc(1, sizeof(function));
-    parent->f = f;
-    parent->next = child;
-}
-
 timed_function *register_timer(bot_t *bot, struct timeval delay,
                                int count, void (*f)(bot_t *, void *))
 {

--- a/src/bot.h
+++ b/src/bot.h
@@ -64,7 +64,7 @@ struct _bot_internal {
 };
 
 struct _function {
-    void (*f)(bot_t *, void *);
+    void *f;
     struct _function *next;
 };
 

--- a/src/client.c
+++ b/src/client.c
@@ -274,611 +274,560 @@ void *schedule_executor(void *index)
     return NULL;
 }
 
-void packet_callback(bot_t *bot, void *packet_struct, void *function) {
+void packet_callback(bot_t *bot, void *packet_struct, void *function)
+{
     int packet_id = ((protocol_dummy_t *)packet_struct)->packet_id;
     switch (bot->_data->current_state) {
-        case HANDSHAKE:
-            switch (packet_id) {
-            }
-            break;
-        case LOGIN:
-            switch (packet_id) {
-            case 0x00:
-                {
-                login_clientbound_disconnect_t *p = packet_struct;
-                void (*f)(bot_t *, char *) = function;
-                f(bot, p->json);
-                break;
-                }
-            case 0x02:
-                {
-                login_clientbound_success_t *p = packet_struct;
-                void (*f)(bot_t *, char *, char *) = function;
-                f(bot, p->uuid, p->username);
-                break;
-                }
-            case 0x03:
-                {
-                login_clientbound_set_compression_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t) = function;
-                f(bot, p->threshold);
-                break;
-                }
-            }
-            break;
-        case STATUS:
-            switch (packet_id) {
-            case 0x00:
-                {
-                status_clientbound_response_t *p = packet_struct;
-                void (*f)(bot_t *, char *) = function;
-                f(bot, p->json);
-                break;
-                }
-            case 0x01:
-                {
-                status_clientbound_ping_t *p = packet_struct;
-                void (*f)(bot_t *, int64_t) = function;
-                f(bot, p->time);
-                break;
-                }
-            }
-            break;
-        case PLAY:
-            switch (packet_id) {
-            case 0x00:
-                {
-                play_clientbound_keepalive_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t) = function;
-                f(bot, p->keepalive_id);
-                break;
-                }
-            case 0x01:
-                {
-                play_clientbound_join_game_t *p = packet_struct;
-                void (*f)(bot_t *, int32_t, 
-                        uint8_t, 
-                        int8_t, 
-                        uint8_t, 
-                        uint8_t, 
-                        char*) = function;
-                f(bot, p->entity_id,
-                        p->gamemode,
-                        p->dimension,
-                        p->difficulty,
-                        p->max_players,
-                        p->level_type);
-                break;
-                }
-            case 0x02:
-                {
-                play_clientbound_chat_t *p = packet_struct;
-                void (*f)(bot_t *, char *, int8_t) = function;
-                f(bot, p->json, p->position);
-                break;
-                }
-            case 0x03:
-                {
-                play_clientbound_time_update_t *p = packet_struct;
-                void (*f)(bot_t *, int64_t, int64_t) = function;
-                f(bot, p->age, p->time);
-                break;
-                }
-            case 0x04:
-                {
-                play_clientbound_entity_equipment_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t, int16_t, slot_t) = function;
-                f(bot, p->entity_id, p->slot, p->item);
-                break;
-                }
-            case 0x05:
-                {
-                play_clientbound_spawn_position_t *p = packet_struct;
-                void (*f)(bot_t *, position_t) = function;
-                f(bot, p->location);
-                break;
-                }
-            case 0x06:
-                {
-                play_clientbound_update_health_t *p = packet_struct;
-                void (*f)(bot_t *, float, vint32_t, float) = function;
-                f(bot, p->health, p->food, p->saturation);
-                break;
-                }
-            case 0x07:
-                {
-                play_clientbound_respawn_t *p = packet_struct;
-                void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *) = function;
-                f(bot, p->dimension, p->difficulty, p->gamemode, p->level_type);
-                break;
-                }
-            case 0x08:
-                {
-                play_clientbound_position_t *p = packet_struct;
-                void (*f)(bot_t *, double,
-                        double,
-                        double,
-                        float,
-                        float,
-                        int8_t) = function;
-                f(bot, p->x, p->y, p->z, p->yaw, p->pitch, p->flags);
-                break;
-                }
-            case 0x09:
-                {
-                play_clientbound_item_change_t *p = packet_struct;
-                void (*f)(bot_t *, int8_t) = function;
-                f(bot, p->slot);
-                break;
-                }
-            case 0x0A:
-                {
-                play_clientbound_use_bed_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t, position_t) = function;
-                f(bot, p->entity_id, p->location);
-                break;
-                }
-            case 0x0B:
-                {
-                play_clientbound_animation_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t, uint8_t) = function;
-                f(bot, p->entity_id, p->animation);
-                break;
-                }
-            case 0x0C:
-                {
-                play_clientbound_spawn_player_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        __uint128_t,
-                        int32_t,
-                        int32_t,
-                        int32_t,
-                        int8_t,
-                        int8_t,
-                        int16_t,
-                        metadata_t) = function;
-                f(bot, p->entity_id,
-                        p->uuid,
-                        p->x,
-                        p->y,
-                        p->z,
-                        p->yaw,
-                        p->pitch,
-                        p->item,
-                        p->metadata);
-                break;
-                }
-            case 0x0D:
-                {
-                play_clientbound_collect_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t, vint32_t) = function;
-                f(bot, p->collected_entity_id, p->collector_entity_id);
-                break;
-                }
-            case 0x0E:
-                {
-                play_clientbound_spawn_object_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int8_t,
-                        int32_t,
-                        int32_t,
-                        int32_t,
-                        int8_t,
-                        int8_t,
-                        data_t) = function;
-                f(bot, p->entity_id,
-                        p->type,
-                        p->x,
-                        p->y,
-                        p->z,
-                        p->yaw,
-                        p->pitch,
-                        p->data);
-                break;
-                }
-            case 0x0F:
-                {
-                play_clientbound_spawn_mob_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        uint8_t,
-                        int32_t,
-                        int32_t,
-                        int32_t,
-                        int8_t,
-                        int8_t,
-                        int8_t,
-                        int16_t,
-                        int16_t,
-                        int16_t,
-                        metadata_t) = function;
-                f(bot, p->entity_id, 
-                        p->type, 
-                        p->x, 
-                        p->y, 
-                        p->z, 
-                        p->yaw, 
-                        p->pitch,
-                        p->head_pitch,
-                        p->dx,
-                        p->dy,
-                        p->dz,
-                        p->metadata);
-                break;
-                }
-            case 0x10:
-                {
-                play_clientbound_spawn_painting_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        char *,
-                        position_t,
-                        uint8_t) = function;
-                f(bot, p->entity_id,
-                        p->title,
-                        p->location,
-                        p->direction);
-                break;
-                }
-            case 0x11:
-                {
-                play_clientbound_spawn_xp_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int32_t,
-                        int32_t,
-                        int32_t,
-                        int16_t) = function;
-                f(bot, p->entity_id,
-                        p->x,
-                        p->y,
-                        p->z,
-                        p->count);
-                break;
-                }
-            case 0x12:
-                {
-                play_clientbound_entity_velocity_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int16_t,
-                        int16_t,
-                        int16_t) = function;
-                f(bot, p->entity_id,
-                        p->dx,
-                        p->dy,
-                        p->dz);
-                break;
-                }
-            case 0x13:
-                {
-                play_clientbound_entity_destroy_entities_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t, vint32_t *) = function;
-                f(bot, p->count, p->entity_ids);
-                break;
-                }
-            case 0x14:
-                {
-                play_clientbound_entity_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t) = function;
-                f(bot, p->entity_id);
-                break;
-                }
-            case 0x15:
-                {
-                play_clientbound_entity_move_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int8_t,
-                        int8_t,
-                        int8_t,
-                        bool) = function;
-                f(bot, p->entity_id,
-                        p->dx,
-                        p->dy,
-                        p->dz,
-                        p->on_ground);
-                break;
-                }
-            case 0x16:
-                {
-                play_clientbound_entity_look_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int8_t,
-                        int8_t,
-                        bool,
-                        int8_t) = function;
-                f(bot, p->entity_id,
-                        p->yaw,
-                        p->pitch,
-                        p->on_ground,
-                        p->pitch_fraction);
-                break;
-                }
-            case 0x17:
-                {
-                play_clientbound_entity_look_move_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int8_t,
-                        int8_t,
-                        int8_t,
-                        int8_t,
-                        int8_t,
-                        bool) = function;
-                f(bot, p->entity_id,
-                        p->dx,
-                        p->dy,
-                        p->dz,
-                        p->yaw,
-                        p->pitch,
-                        p->on_ground);
-                break;
-                }
-            case 0x18:
-                {
-                play_clientbound_entity_teleport_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int32_t,
-                        int32_t,
-                        int32_t,
-                        int8_t,
-                        int8_t,
-                        bool) = function;
-                f(bot, p->entity_id,
-                        p->x,
-                        p->y,
-                        p->z,
-                        p->yaw,
-                        p->pitch,
-                        p->on_ground);
-                break;
-                }
-            case 0x19:
-                {
-                play_clientbound_entity_head_look_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int8_t) = function;
-                f(bot, p->entity_id, p->yaw);
-                break;
-                }
-            case 0x1A:
-                {
-                play_clientbound_entity_status_t *p = packet_struct;
-                void (*f)(bot_t *, int32_t,
-                        int8_t) = function;
-                f(bot, p->entity_id, p->status);
-                break;
-                }
-            case 0x1B:
-                {
-                play_clientbound_entity_attach_t *p = packet_struct;
-                void (*f)(bot_t *, int32_t,
-                        int32_t,
-                        bool) = function;
-                f(bot, p->entity_id, p->vehicle_id, p->leash);
-                break;
-                }
-            case 0x1D:
-                {
-                play_clientbound_entity_effect_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int8_t,
-                        int8_t,
-                        vint32_t,
-                        bool) = function;
-                f(bot, p->entity_id,
-                        p->effect_id,
-                        p->amplifier,
-                        p->duration,
-                        p->hide);
-                break;
-                }
-            case 0x1E:
-                {
-                play_clientbound_entity_clear_effect_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t, int8_t) = function;
-                f(bot, p->entity_id, p->effect_id);
-                break;
-                }
-            case 0x20:
-                {
-                play_clientbound_entity_properties_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int32_t,
-                        property_t *) = function;
-                f(bot, p->entity_id, p->count, p->properties);
-                break;
-                }
-            case 0x1F:
-                {
-                play_clientbound_set_xp_t *p = packet_struct;
-                void (*f)(bot_t *, float, int32_t, int32_t) = function;
-                f(bot, p->xp_bar, p->level, p->xp);
-                break;
-                }
-            case 0x21:
-                {
-                play_clientbound_chunk_data_t *p = packet_struct;
-                void (*f)(bot_t *, int32_t,
-                        int32_t,
-                        bool,
-                        uint16_t,
-                        vint32_t,
-                        int8_t *) = function;
-                f(bot, p->chunk_x,
-                        p->chunk_z,
-                        p->continuous,
-                        p->bitmap,
-                        p->size,
-                        p->data);
-                break;
-                }
-            case 0x22:
-                {
-                play_clientbound_multi_block_change_t *p = packet_struct;
-                void (*f)(bot_t *, int32_t,
-                        int32_t,
-                        vint32_t,
-                        record_t *) = function;
-                f(bot, p->chunk_x,
-                        p->chunk_z,
-                        p->count,
-                        p->records);
-                break;
-                }
-            case 0x23:
-                {
-                play_clientbound_block_change_t *p = packet_struct;
-                void (*f)(bot_t *, position_t, vint32_t) = function;
-                f(bot, p->location, p->block_id);
-                break;
-                }
-            case 0x24:
-                {
-                play_clientbound_block_action_t *p = packet_struct;
-                void (*f)(bot_t *, position_t,
-                        uint8_t,
-                        uint8_t,
-                        vint32_t) = function;
-                f(bot, p->location,
-                        p->byte1,
-                        p->byte2,
-                        p->type);
-                break;
-                }
-            case 0x25:
-                {
-                play_clientbound_block_break_animation_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t, position_t, int8_t) = function;
-                f(bot, p->entity_id, p->location, p->stage);
-                break;
-                }
-            case 0x26:
-                {
-                play_clientbound_chunk_bulk_t *p = packet_struct;
-                void (*f)(bot_t *, bool,
-                        vint32_t,
-                        int32_t,
-                        int32_t,
-                        uint16_t,
-                        int8_t *) = function;
-                f(bot, p->skylight,
-                        p->column_count,
-                        p->chunk_x,
-                        p->chunk_z,
-                        p->bitmap,
-                        p->data);
-                break;
-                }
-            case 0x27:
-                {
-                play_clientbound_explosion_t *p = packet_struct;
-                void (*f)(bot_t *, float,
-                        float,
-                        float,
-                        float,
-                        int32_t,
-                        record_t *,
-                        float,
-                        float,
-                        float) = function;
-                f(bot, p->x,
-                        p->y,
-                        p->z,
-                        p->radius,
-                        p->count,
-                        p->records,
-                        p->dx,
-                        p->dy,
-                        p->dz);
-                break;
-                }
-            case 0x28:
-                {
-                play_clientbound_effect_t *p = packet_struct;
-                void (*f)(bot_t *, int32_t,
-                        position_t,
-                        int32_t,
-                        bool) = function;
-                f(bot, p->effect_id,
-                        p->location,
-                        p->data,
-                        p->relative);
-                break;
-                }
-            case 0x29:
-                {
-                play_clientbound_sound_effect_t *p = packet_struct;
-                void (*f)(bot_t *, char *,
-                        int32_t,
-                        int32_t,
-                        int32_t,
-                        float,
-                        uint8_t) = function;
-                f(bot, p->sound_name,
-                        p->x,
-                        p->y,
-                        p->z,
-                        p->volume,
-                        p->pitch);
-                break;
-                }
-            case 0x2C:
-                {
-                play_clientbound_entity_spawn_global_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t,
-                        int8_t,
-                        int32_t,
-                        int32_t,
-                        int32_t) = function;
-                f(bot, p->entity_id,
-                        p->type,
-                        p->x,
-                        p->y,
-                        p->z);
-                break;
-                }
-            case 0x33:
-                {
-                play_clientbound_update_sign_t *p = packet_struct;
-                void (*f)(bot_t *, position_t,
-                        chat_t,
-                        chat_t,
-                        chat_t,
-                        chat_t) = function;
-                f(bot, p->location,
-                        p->line1,
-                        p->line2,
-                        p->line3,
-                        p->line4);
-                break;
-                }
-            case 0x3F:
-                {
-                play_clientbound_plugin_message_t *p = packet_struct;
-                void (*f)(bot_t *, char *, int8_t *) = function;
-                f(bot, p->channel, p->data);
-                break;
-                }
-            case 0x40:
-                {
-                play_clientbound_plugin_disconnect_t *p = packet_struct;
-                void (*f)(bot_t *, char *) = function;
-                f(bot, p->reason);
-                break;
-                }
-            case 0x41:
-                {
-                play_clientbound_plugin_difficulty_t *p = packet_struct;
-                void (*f)(bot_t *, uint8_t) = function;
-                f(bot, p->difficulty);
-                break;
-                }
-            case 0x46:
-                {
-                play_clientbound_set_compression_t *p = packet_struct;
-                void (*f)(bot_t *, vint32_t) = function;
-                f(bot, p->threshold);
-                break;
-                }
-            }
-            break;
-        default:
+    case HANDSHAKE:
+        switch (packet_id) {
+        }
+        break;
+    case LOGIN:
+        switch (packet_id) {
+        case 0x00: {
+            login_clientbound_disconnect_t *p = packet_struct;
+            void (*f)(bot_t *, char *) = function;
+            f(bot, p->json);
             break;
         }
+        case 0x02: {
+            login_clientbound_success_t *p = packet_struct;
+            void (*f)(bot_t *, char *, char *) = function;
+            f(bot, p->uuid, p->username);
+            break;
+        }
+        case 0x03: {
+            login_clientbound_set_compression_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t) = function;
+            f(bot, p->threshold);
+            break;
+        }
+        }
+        break;
+    case STATUS:
+        switch (packet_id) {
+        case 0x00: {
+            status_clientbound_response_t *p = packet_struct;
+            void (*f)(bot_t *, char *) = function;
+            f(bot, p->json);
+            break;
+        }
+        case 0x01: {
+            status_clientbound_ping_t *p = packet_struct;
+            void (*f)(bot_t *, int64_t) = function;
+            f(bot, p->time);
+            break;
+        }
+        }
+        break;
+    case PLAY:
+        switch (packet_id) {
+        case 0x00: {
+            play_clientbound_keepalive_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t) = function;
+            f(bot, p->keepalive_id);
+            break;
+        }
+        case 0x01: {
+            play_clientbound_join_game_t *p = packet_struct;
+            void (*f)(bot_t *, int32_t,
+                      uint8_t,
+                      int8_t,
+                      uint8_t,
+                      uint8_t,
+                      char*) = function;
+            f(bot, p->entity_id,
+              p->gamemode,
+              p->dimension,
+              p->difficulty,
+              p->max_players,
+              p->level_type);
+            break;
+        }
+        case 0x02: {
+            play_clientbound_chat_t *p = packet_struct;
+            void (*f)(bot_t *, char *, int8_t) = function;
+            f(bot, p->json, p->position);
+            break;
+        }
+        case 0x03: {
+            play_clientbound_time_update_t *p = packet_struct;
+            void (*f)(bot_t *, int64_t, int64_t) = function;
+            f(bot, p->age, p->time);
+            break;
+        }
+        case 0x04: {
+            play_clientbound_entity_equipment_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t, int16_t, slot_t) = function;
+            f(bot, p->entity_id, p->slot, p->item);
+            break;
+        }
+        case 0x05: {
+            play_clientbound_spawn_position_t *p = packet_struct;
+            void (*f)(bot_t *, position_t) = function;
+            f(bot, p->location);
+            break;
+        }
+        case 0x06: {
+            play_clientbound_update_health_t *p = packet_struct;
+            void (*f)(bot_t *, float, vint32_t, float) = function;
+            f(bot, p->health, p->food, p->saturation);
+            break;
+        }
+        case 0x07: {
+            play_clientbound_respawn_t *p = packet_struct;
+            void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *) = function;
+            f(bot, p->dimension, p->difficulty, p->gamemode, p->level_type);
+            break;
+        }
+        case 0x08: {
+            play_clientbound_position_t *p = packet_struct;
+            void (*f)(bot_t *, double,
+                      double,
+                      double,
+                      float,
+                      float,
+                      int8_t) = function;
+            f(bot, p->x, p->y, p->z, p->yaw, p->pitch, p->flags);
+            break;
+        }
+        case 0x09: {
+            play_clientbound_item_change_t *p = packet_struct;
+            void (*f)(bot_t *, int8_t) = function;
+            f(bot, p->slot);
+            break;
+        }
+        case 0x0A: {
+            play_clientbound_use_bed_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t, position_t) = function;
+            f(bot, p->entity_id, p->location);
+            break;
+        }
+        case 0x0B: {
+            play_clientbound_animation_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t, uint8_t) = function;
+            f(bot, p->entity_id, p->animation);
+            break;
+        }
+        case 0x0C: {
+            play_clientbound_spawn_player_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      __uint128_t,
+                      int32_t,
+                      int32_t,
+                      int32_t,
+                      int8_t,
+                      int8_t,
+                      int16_t,
+                      metadata_t) = function;
+            f(bot, p->entity_id,
+              p->uuid,
+              p->x,
+              p->y,
+              p->z,
+              p->yaw,
+              p->pitch,
+              p->item,
+              p->metadata);
+            break;
+        }
+        case 0x0D: {
+            play_clientbound_collect_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t, vint32_t) = function;
+            f(bot, p->collected_entity_id, p->collector_entity_id);
+            break;
+        }
+        case 0x0E: {
+            play_clientbound_spawn_object_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int8_t,
+                      int32_t,
+                      int32_t,
+                      int32_t,
+                      int8_t,
+                      int8_t,
+                      data_t) = function;
+            f(bot, p->entity_id,
+              p->type,
+              p->x,
+              p->y,
+              p->z,
+              p->yaw,
+              p->pitch,
+              p->data);
+            break;
+        }
+        case 0x0F: {
+            play_clientbound_spawn_mob_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      uint8_t,
+                      int32_t,
+                      int32_t,
+                      int32_t,
+                      int8_t,
+                      int8_t,
+                      int8_t,
+                      int16_t,
+                      int16_t,
+                      int16_t,
+                      metadata_t) = function;
+            f(bot, p->entity_id,
+              p->type,
+              p->x,
+              p->y,
+              p->z,
+              p->yaw,
+              p->pitch,
+              p->head_pitch,
+              p->dx,
+              p->dy,
+              p->dz,
+              p->metadata);
+            break;
+        }
+        case 0x10: {
+            play_clientbound_spawn_painting_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      char *,
+                      position_t,
+                      uint8_t) = function;
+            f(bot, p->entity_id,
+              p->title,
+              p->location,
+              p->direction);
+            break;
+        }
+        case 0x11: {
+            play_clientbound_spawn_xp_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int32_t,
+                      int32_t,
+                      int32_t,
+                      int16_t) = function;
+            f(bot, p->entity_id,
+              p->x,
+              p->y,
+              p->z,
+              p->count);
+            break;
+        }
+        case 0x12: {
+            play_clientbound_entity_velocity_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int16_t,
+                      int16_t,
+                      int16_t) = function;
+            f(bot, p->entity_id,
+              p->dx,
+              p->dy,
+              p->dz);
+            break;
+        }
+        case 0x13: {
+            play_clientbound_entity_destroy_entities_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t, vint32_t *) = function;
+            f(bot, p->count, p->entity_ids);
+            break;
+        }
+        case 0x14: {
+            play_clientbound_entity_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t) = function;
+            f(bot, p->entity_id);
+            break;
+        }
+        case 0x15: {
+            play_clientbound_entity_move_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int8_t,
+                      int8_t,
+                      int8_t,
+                      bool) = function;
+            f(bot, p->entity_id,
+              p->dx,
+              p->dy,
+              p->dz,
+              p->on_ground);
+            break;
+        }
+        case 0x16: {
+            play_clientbound_entity_look_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int8_t,
+                      int8_t,
+                      bool,
+                      int8_t) = function;
+            f(bot, p->entity_id,
+              p->yaw,
+              p->pitch,
+              p->on_ground,
+              p->pitch_fraction);
+            break;
+        }
+        case 0x17: {
+            play_clientbound_entity_look_move_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int8_t,
+                      int8_t,
+                      int8_t,
+                      int8_t,
+                      int8_t,
+                      bool) = function;
+            f(bot, p->entity_id,
+              p->dx,
+              p->dy,
+              p->dz,
+              p->yaw,
+              p->pitch,
+              p->on_ground);
+            break;
+        }
+        case 0x18: {
+            play_clientbound_entity_teleport_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int32_t,
+                      int32_t,
+                      int32_t,
+                      int8_t,
+                      int8_t,
+                      bool) = function;
+            f(bot, p->entity_id,
+              p->x,
+              p->y,
+              p->z,
+              p->yaw,
+              p->pitch,
+              p->on_ground);
+            break;
+        }
+        case 0x19: {
+            play_clientbound_entity_head_look_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int8_t) = function;
+            f(bot, p->entity_id, p->yaw);
+            break;
+        }
+        case 0x1A: {
+            play_clientbound_entity_status_t *p = packet_struct;
+            void (*f)(bot_t *, int32_t,
+                      int8_t) = function;
+            f(bot, p->entity_id, p->status);
+            break;
+        }
+        case 0x1B: {
+            play_clientbound_entity_attach_t *p = packet_struct;
+            void (*f)(bot_t *, int32_t,
+                      int32_t,
+                      bool) = function;
+            f(bot, p->entity_id, p->vehicle_id, p->leash);
+            break;
+        }
+        case 0x1D: {
+            play_clientbound_entity_effect_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int8_t,
+                      int8_t,
+                      vint32_t,
+                      bool) = function;
+            f(bot, p->entity_id,
+              p->effect_id,
+              p->amplifier,
+              p->duration,
+              p->hide);
+            break;
+        }
+        case 0x1E: {
+            play_clientbound_entity_clear_effect_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t, int8_t) = function;
+            f(bot, p->entity_id, p->effect_id);
+            break;
+        }
+        case 0x20: {
+            play_clientbound_entity_properties_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int32_t,
+                      property_t *) = function;
+            f(bot, p->entity_id, p->count, p->properties);
+            break;
+        }
+        case 0x1F: {
+            play_clientbound_set_xp_t *p = packet_struct;
+            void (*f)(bot_t *, float, int32_t, int32_t) = function;
+            f(bot, p->xp_bar, p->level, p->xp);
+            break;
+        }
+        case 0x21: {
+            play_clientbound_chunk_data_t *p = packet_struct;
+            void (*f)(bot_t *, int32_t,
+                      int32_t,
+                      bool,
+                      uint16_t,
+                      vint32_t,
+                      int8_t *) = function;
+            f(bot, p->chunk_x,
+              p->chunk_z,
+              p->continuous,
+              p->bitmap,
+              p->size,
+              p->data);
+            break;
+        }
+        case 0x22: {
+            play_clientbound_multi_block_change_t *p = packet_struct;
+            void (*f)(bot_t *, int32_t,
+                      int32_t,
+                      vint32_t,
+                      record_t *) = function;
+            f(bot, p->chunk_x,
+              p->chunk_z,
+              p->count,
+              p->records);
+            break;
+        }
+        case 0x23: {
+            play_clientbound_block_change_t *p = packet_struct;
+            void (*f)(bot_t *, position_t, vint32_t) = function;
+            f(bot, p->location, p->block_id);
+            break;
+        }
+        case 0x24: {
+            play_clientbound_block_action_t *p = packet_struct;
+            void (*f)(bot_t *, position_t,
+                      uint8_t,
+                      uint8_t,
+                      vint32_t) = function;
+            f(bot, p->location,
+              p->byte1,
+              p->byte2,
+              p->type);
+            break;
+        }
+        case 0x25: {
+            play_clientbound_block_break_animation_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t, position_t, int8_t) = function;
+            f(bot, p->entity_id, p->location, p->stage);
+            break;
+        }
+        case 0x26: {
+            play_clientbound_chunk_bulk_t *p = packet_struct;
+            void (*f)(bot_t *, bool,
+                      vint32_t,
+                      int32_t,
+                      int32_t,
+                      uint16_t,
+                      int8_t *) = function;
+            f(bot, p->skylight,
+              p->column_count,
+              p->chunk_x,
+              p->chunk_z,
+              p->bitmap,
+              p->data);
+            break;
+        }
+        case 0x27: {
+            play_clientbound_explosion_t *p = packet_struct;
+            void (*f)(bot_t *, float,
+                      float,
+                      float,
+                      float,
+                      int32_t,
+                      record_t *,
+                      float,
+                      float,
+                      float) = function;
+            f(bot, p->x,
+              p->y,
+              p->z,
+              p->radius,
+              p->count,
+              p->records,
+              p->dx,
+              p->dy,
+              p->dz);
+            break;
+        }
+        case 0x28: {
+            play_clientbound_effect_t *p = packet_struct;
+            void (*f)(bot_t *, int32_t,
+                      position_t,
+                      int32_t,
+                      bool) = function;
+            f(bot, p->effect_id,
+              p->location,
+              p->data,
+              p->relative);
+            break;
+        }
+        case 0x29: {
+            play_clientbound_sound_effect_t *p = packet_struct;
+            void (*f)(bot_t *, char *,
+                      int32_t,
+                      int32_t,
+                      int32_t,
+                      float,
+                      uint8_t) = function;
+            f(bot, p->sound_name,
+              p->x,
+              p->y,
+              p->z,
+              p->volume,
+              p->pitch);
+            break;
+        }
+        case 0x2C: {
+            play_clientbound_entity_spawn_global_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t,
+                      int8_t,
+                      int32_t,
+                      int32_t,
+                      int32_t) = function;
+            f(bot, p->entity_id,
+              p->type,
+              p->x,
+              p->y,
+              p->z);
+            break;
+        }
+        case 0x33: {
+            play_clientbound_update_sign_t *p = packet_struct;
+            void (*f)(bot_t *, position_t,
+                      chat_t,
+                      chat_t,
+                      chat_t,
+                      chat_t) = function;
+            f(bot, p->location,
+              p->line1,
+              p->line2,
+              p->line3,
+              p->line4);
+            break;
+        }
+        case 0x3F: {
+            play_clientbound_plugin_message_t *p = packet_struct;
+            void (*f)(bot_t *, char *, int8_t *) = function;
+            f(bot, p->channel, p->data);
+            break;
+        }
+        case 0x40: {
+            play_clientbound_plugin_disconnect_t *p = packet_struct;
+            void (*f)(bot_t *, char *) = function;
+            f(bot, p->reason);
+            break;
+        }
+        case 0x41: {
+            play_clientbound_plugin_difficulty_t *p = packet_struct;
+            void (*f)(bot_t *, uint8_t) = function;
+            f(bot, p->difficulty);
+            break;
+        }
+        case 0x46: {
+            play_clientbound_set_compression_t *p = packet_struct;
+            void (*f)(bot_t *, vint32_t) = function;
+            f(bot, p->threshold);
+            break;
+        }
+        }
+        break;
+    default:
+        break;
+    }
 }

--- a/src/client.c
+++ b/src/client.c
@@ -169,7 +169,7 @@ void *callback_listener(void *index)
     pipe_producer_t *p = pipe_producer_new(pipes[i]);
     while (1) {
         ready = poll(&fds, 1, -1);
-        if(ready < 0)
+        if(bot, ready < 0)
             perror("event listener");
         // read packet
         // send signal to corresponding thread
@@ -286,22 +286,22 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x00:
                 {
                 login_clientbound_disconnect_t *p = packet_struct;
-                void (*f)(char *) = function;
-                f(p->json);
+                void (*f)(bot_t *, char *) = function;
+                f(bot, p->json);
                 break;
                 }
             case 0x02:
                 {
                 login_clientbound_success_t *p = packet_struct;
-                void (*f)(char *, char *) = function;
-                f(p->uuid, p->username);
+                void (*f)(bot_t *, char *, char *) = function;
+                f(bot, p->uuid, p->username);
                 break;
                 }
             case 0x03:
                 {
                 login_clientbound_set_compression_t *p = packet_struct;
-                void (*f)(vint32_t) = function;
-                f(p->threshold);
+                void (*f)(bot_t *, vint32_t) = function;
+                f(bot, p->threshold);
                 break;
                 }
             }
@@ -311,15 +311,15 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x00:
                 {
                 status_clientbound_response_t *p = packet_struct;
-                void (*f)(char *) = function;
-                f(p->json);
+                void (*f)(bot_t *, char *) = function;
+                f(bot, p->json);
                 break;
                 }
             case 0x01:
                 {
                 status_clientbound_ping_t *p = packet_struct;
-                void (*f)(int64_t) = function;
-                f(p->time);
+                void (*f)(bot_t *, int64_t) = function;
+                f(bot, p->time);
                 break;
                 }
             }
@@ -329,20 +329,20 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x00:
                 {
                 play_clientbound_keepalive_t *p = packet_struct;
-                void (*f)(vint32_t) = function;
-                f(p->keepalive_id);
+                void (*f)(bot_t *, vint32_t) = function;
+                f(bot, p->keepalive_id);
                 break;
                 }
             case 0x01:
                 {
                 play_clientbound_join_game_t *p = packet_struct;
-                void (*f)(int32_t, 
+                void (*f)(bot_t *, int32_t, 
                         uint8_t, 
                         int8_t, 
                         uint8_t, 
                         uint8_t, 
                         char*) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->gamemode,
                         p->dimension,
                         p->difficulty,
@@ -353,82 +353,82 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x02:
                 {
                 play_clientbound_chat_t *p = packet_struct;
-                void (*f)(char *, int8_t) = function;
-                f(p->json, p->position);
+                void (*f)(bot_t *, char *, int8_t) = function;
+                f(bot, p->json, p->position);
                 break;
                 }
             case 0x03:
                 {
                 play_clientbound_time_update_t *p = packet_struct;
-                void (*f)(int64_t, int64_t) = function;
-                f(p->age, p->time);
+                void (*f)(bot_t *, int64_t, int64_t) = function;
+                f(bot, p->age, p->time);
                 break;
                 }
             case 0x04:
                 {
                 play_clientbound_entity_equipment_t *p = packet_struct;
-                void (*f)(vint32_t, int16_t, slot_t) = function;
-                f(p->entity_id, p->slot, p->item);
+                void (*f)(bot_t *, vint32_t, int16_t, slot_t) = function;
+                f(bot, p->entity_id, p->slot, p->item);
                 break;
                 }
             case 0x05:
                 {
                 play_clientbound_spawn_position_t *p = packet_struct;
-                void (*f)(position_t) = function;
-                f(p->location);
+                void (*f)(bot_t *, position_t) = function;
+                f(bot, p->location);
                 break;
                 }
             case 0x06:
                 {
                 play_clientbound_update_health_t *p = packet_struct;
-                void (*f)(float, vint32_t, float) = function;
-                f(p->health, p->food, p->saturation);
+                void (*f)(bot_t *, float, vint32_t, float) = function;
+                f(bot, p->health, p->food, p->saturation);
                 break;
                 }
             case 0x07:
                 {
                 play_clientbound_respawn_t *p = packet_struct;
-                void (*f)(int32_t, uint8_t, uint8_t, char *) = function;
-                f(p->dimension, p->difficulty, p->gamemode, p->level_type);
+                void (*f)(bot_t *, int32_t, uint8_t, uint8_t, char *) = function;
+                f(bot, p->dimension, p->difficulty, p->gamemode, p->level_type);
                 break;
                 }
             case 0x08:
                 {
                 play_clientbound_position_t *p = packet_struct;
-                void (*f)(double,
+                void (*f)(bot_t *, double,
                         double,
                         double,
                         float,
                         float,
                         int8_t) = function;
-                f(p->x, p->y, p->z, p->yaw, p->pitch, p->flags);
+                f(bot, p->x, p->y, p->z, p->yaw, p->pitch, p->flags);
                 break;
                 }
             case 0x09:
                 {
                 play_clientbound_item_change_t *p = packet_struct;
-                void (*f)(int8_t) = function;
-                f(p->slot);
+                void (*f)(bot_t *, int8_t) = function;
+                f(bot, p->slot);
                 break;
                 }
             case 0x0A:
                 {
                 play_clientbound_use_bed_t *p = packet_struct;
-                void (*f)(vint32_t, position_t) = function;
-                f(p->entity_id, p->location);
+                void (*f)(bot_t *, vint32_t, position_t) = function;
+                f(bot, p->entity_id, p->location);
                 break;
                 }
             case 0x0B:
                 {
                 play_clientbound_animation_t *p = packet_struct;
-                void (*f)(vint32_t, uint8_t) = function;
-                f(p->entity_id, p->animation);
+                void (*f)(bot_t *, vint32_t, uint8_t) = function;
+                f(bot, p->entity_id, p->animation);
                 break;
                 }
             case 0x0C:
                 {
                 play_clientbound_spawn_player_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         __uint128_t,
                         int32_t,
                         int32_t,
@@ -437,7 +437,7 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
                         int8_t,
                         int16_t,
                         metadata_t) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->uuid,
                         p->x,
                         p->y,
@@ -451,14 +451,14 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x0D:
                 {
                 play_clientbound_collect_t *p = packet_struct;
-                void (*f)(vint32_t, vint32_t) = function;
-                f(p->collected_entity_id, p->collector_entity_id);
+                void (*f)(bot_t *, vint32_t, vint32_t) = function;
+                f(bot, p->collected_entity_id, p->collector_entity_id);
                 break;
                 }
             case 0x0E:
                 {
                 play_clientbound_spawn_object_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int8_t,
                         int32_t,
                         int32_t,
@@ -466,7 +466,7 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
                         int8_t,
                         int8_t,
                         data_t) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->type,
                         p->x,
                         p->y,
@@ -479,7 +479,7 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x0F:
                 {
                 play_clientbound_spawn_mob_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         uint8_t,
                         int32_t,
                         int32_t,
@@ -491,7 +491,7 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
                         int16_t,
                         int16_t,
                         metadata_t) = function;
-                f(p->entity_id, 
+                f(bot, p->entity_id, 
                         p->type, 
                         p->x, 
                         p->y, 
@@ -508,11 +508,11 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x10:
                 {
                 play_clientbound_spawn_painting_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         char *,
                         position_t,
                         uint8_t) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->title,
                         p->location,
                         p->direction);
@@ -521,12 +521,12 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x11:
                 {
                 play_clientbound_spawn_xp_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int32_t,
                         int32_t,
                         int32_t,
                         int16_t) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->x,
                         p->y,
                         p->z,
@@ -536,11 +536,11 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x12:
                 {
                 play_clientbound_entity_velocity_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int16_t,
                         int16_t,
                         int16_t) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->dx,
                         p->dy,
                         p->dz);
@@ -549,26 +549,26 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x13:
                 {
                 play_clientbound_entity_destroy_entities_t *p = packet_struct;
-                void (*f)(vint32_t, vint32_t *) = function;
-                f(p->count, p->entity_ids);
+                void (*f)(bot_t *, vint32_t, vint32_t *) = function;
+                f(bot, p->count, p->entity_ids);
                 break;
                 }
             case 0x14:
                 {
                 play_clientbound_entity_t *p = packet_struct;
-                void (*f)(vint32_t) = function;
-                f(p->entity_id);
+                void (*f)(bot_t *, vint32_t) = function;
+                f(bot, p->entity_id);
                 break;
                 }
             case 0x15:
                 {
                 play_clientbound_entity_move_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int8_t,
                         int8_t,
                         int8_t,
                         bool) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->dx,
                         p->dy,
                         p->dz,
@@ -578,12 +578,12 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x16:
                 {
                 play_clientbound_entity_look_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int8_t,
                         int8_t,
                         bool,
                         int8_t) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->yaw,
                         p->pitch,
                         p->on_ground,
@@ -593,14 +593,14 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x17:
                 {
                 play_clientbound_entity_look_move_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int8_t,
                         int8_t,
                         int8_t,
                         int8_t,
                         int8_t,
                         bool) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->dx,
                         p->dy,
                         p->dz,
@@ -612,14 +612,14 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x18:
                 {
                 play_clientbound_entity_teleport_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int32_t,
                         int32_t,
                         int32_t,
                         int8_t,
                         int8_t,
                         bool) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->x,
                         p->y,
                         p->z,
@@ -631,37 +631,37 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x19:
                 {
                 play_clientbound_entity_head_look_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int8_t) = function;
-                f(p->entity_id, p->yaw);
+                f(bot, p->entity_id, p->yaw);
                 break;
                 }
             case 0x1A:
                 {
                 play_clientbound_entity_status_t *p = packet_struct;
-                void (*f)(int32_t,
+                void (*f)(bot_t *, int32_t,
                         int8_t) = function;
-                f(p->entity_id, p->status);
+                f(bot, p->entity_id, p->status);
                 break;
                 }
             case 0x1B:
                 {
                 play_clientbound_entity_attach_t *p = packet_struct;
-                void (*f)(int32_t,
+                void (*f)(bot_t *, int32_t,
                         int32_t,
                         bool) = function;
-                f(p->entity_id, p->vehicle_id, p->leash);
+                f(bot, p->entity_id, p->vehicle_id, p->leash);
                 break;
                 }
             case 0x1D:
                 {
                 play_clientbound_entity_effect_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int8_t,
                         int8_t,
                         vint32_t,
                         bool) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->effect_id,
                         p->amplifier,
                         p->duration,
@@ -671,36 +671,36 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x1E:
                 {
                 play_clientbound_entity_clear_effect_t *p = packet_struct;
-                void (*f)(vint32_t, int8_t) = function;
-                f(p->entity_id, p->effect_id);
+                void (*f)(bot_t *, vint32_t, int8_t) = function;
+                f(bot, p->entity_id, p->effect_id);
                 break;
                 }
             case 0x20:
                 {
                 play_clientbound_entity_properties_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int32_t,
                         property_t *) = function;
-                f(p->entity_id, p->count, p->properties);
+                f(bot, p->entity_id, p->count, p->properties);
                 break;
                 }
             case 0x1F:
                 {
                 play_clientbound_set_xp_t *p = packet_struct;
-                void (*f)(float, int32_t, int32_t) = function;
-                f(p->xp_bar, p->level, p->xp);
+                void (*f)(bot_t *, float, int32_t, int32_t) = function;
+                f(bot, p->xp_bar, p->level, p->xp);
                 break;
                 }
             case 0x21:
                 {
                 play_clientbound_chunk_data_t *p = packet_struct;
-                void (*f)(int32_t,
+                void (*f)(bot_t *, int32_t,
                         int32_t,
                         bool,
                         uint16_t,
                         vint32_t,
                         int8_t *) = function;
-                f(p->chunk_x,
+                f(bot, p->chunk_x,
                         p->chunk_z,
                         p->continuous,
                         p->bitmap,
@@ -711,11 +711,11 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x22:
                 {
                 play_clientbound_multi_block_change_t *p = packet_struct;
-                void (*f)(int32_t,
+                void (*f)(bot_t *, int32_t,
                         int32_t,
                         vint32_t,
                         record_t *) = function;
-                f(p->chunk_x,
+                f(bot, p->chunk_x,
                         p->chunk_z,
                         p->count,
                         p->records);
@@ -724,18 +724,18 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x23:
                 {
                 play_clientbound_block_change_t *p = packet_struct;
-                void (*f)(position_t, vint32_t) = function;
-                f(p->location, p->block_id);
+                void (*f)(bot_t *, position_t, vint32_t) = function;
+                f(bot, p->location, p->block_id);
                 break;
                 }
             case 0x24:
                 {
                 play_clientbound_block_action_t *p = packet_struct;
-                void (*f)(position_t,
+                void (*f)(bot_t *, position_t,
                         uint8_t,
                         uint8_t,
                         vint32_t) = function;
-                f(p->location,
+                f(bot, p->location,
                         p->byte1,
                         p->byte2,
                         p->type);
@@ -744,20 +744,20 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x25:
                 {
                 play_clientbound_block_break_animation_t *p = packet_struct;
-                void (*f)(vint32_t, position_t, int8_t) = function;
-                f(p->entity_id, p->location, p->stage);
+                void (*f)(bot_t *, vint32_t, position_t, int8_t) = function;
+                f(bot, p->entity_id, p->location, p->stage);
                 break;
                 }
             case 0x26:
                 {
                 play_clientbound_chunk_bulk_t *p = packet_struct;
-                void (*f)(bool,
+                void (*f)(bot_t *, bool,
                         vint32_t,
                         int32_t,
                         int32_t,
                         uint16_t,
                         int8_t *) = function;
-                f(p->skylight,
+                f(bot, p->skylight,
                         p->column_count,
                         p->chunk_x,
                         p->chunk_z,
@@ -768,7 +768,7 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x27:
                 {
                 play_clientbound_explosion_t *p = packet_struct;
-                void (*f)(float,
+                void (*f)(bot_t *, float,
                         float,
                         float,
                         float,
@@ -777,7 +777,7 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
                         float,
                         float,
                         float) = function;
-                f(p->x,
+                f(bot, p->x,
                         p->y,
                         p->z,
                         p->radius,
@@ -791,11 +791,11 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x28:
                 {
                 play_clientbound_effect_t *p = packet_struct;
-                void (*f)(int32_t,
+                void (*f)(bot_t *, int32_t,
                         position_t,
                         int32_t,
                         bool) = function;
-                f(p->effect_id,
+                f(bot, p->effect_id,
                         p->location,
                         p->data,
                         p->relative);
@@ -804,13 +804,13 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x29:
                 {
                 play_clientbound_sound_effect_t *p = packet_struct;
-                void (*f)(char *,
+                void (*f)(bot_t *, char *,
                         int32_t,
                         int32_t,
                         int32_t,
                         float,
                         uint8_t) = function;
-                f(p->sound_name,
+                f(bot, p->sound_name,
                         p->x,
                         p->y,
                         p->z,
@@ -821,12 +821,12 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x2C:
                 {
                 play_clientbound_entity_spawn_global_t *p = packet_struct;
-                void (*f)(vint32_t,
+                void (*f)(bot_t *, vint32_t,
                         int8_t,
                         int32_t,
                         int32_t,
                         int32_t) = function;
-                f(p->entity_id,
+                f(bot, p->entity_id,
                         p->type,
                         p->x,
                         p->y,
@@ -836,12 +836,12 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x33:
                 {
                 play_clientbound_update_sign_t *p = packet_struct;
-                void (*f)(position_t,
+                void (*f)(bot_t *, position_t,
                         chat_t,
                         chat_t,
                         chat_t,
                         chat_t) = function;
-                f(p->location,
+                f(bot, p->location,
                         p->line1,
                         p->line2,
                         p->line3,
@@ -851,29 +851,29 @@ void packet_callback(bot_t *bot, void *packet_struct, void *function) {
             case 0x3F:
                 {
                 play_clientbound_plugin_message_t *p = packet_struct;
-                void (*f)(char *, int8_t *) = function;
-                f(p->channel, p->data);
+                void (*f)(bot_t *, char *, int8_t *) = function;
+                f(bot, p->channel, p->data);
                 break;
                 }
             case 0x40:
                 {
                 play_clientbound_plugin_disconnect_t *p = packet_struct;
-                void (*f)(char *) = function;
-                f(p->reason);
+                void (*f)(bot_t *, char *) = function;
+                f(bot, p->reason);
                 break;
                 }
             case 0x41:
                 {
                 play_clientbound_plugin_difficulty_t *p = packet_struct;
-                void (*f)(uint8_t) = function;
-                f(p->difficulty);
+                void (*f)(bot_t *, uint8_t) = function;
+                f(bot, p->difficulty);
                 break;
                 }
             case 0x46:
                 {
                 play_clientbound_set_compression_t *p = packet_struct;
-                void (*f)(vint32_t) = function;
-                f(p->threshold);
+                void (*f)(bot_t *, vint32_t) = function;
+                f(bot, p->threshold);
                 break;
                 }
             }

--- a/src/client.c
+++ b/src/client.c
@@ -169,7 +169,7 @@ void *callback_listener(void *index)
     pipe_producer_t *p = pipe_producer_new(pipes[i]);
     while (1) {
         ready = poll(&fds, 1, -1);
-        if(bot, ready < 0)
+        if (ready < 0)
             perror("event listener");
         // read packet
         // send signal to corresponding thread

--- a/src/client.c
+++ b/src/client.c
@@ -54,6 +54,7 @@ void *scheduler(void *index);
 void *schedule_executor(void *index);
 void *bot_thread(void *bot);
 
+void packet_callback(bot_t *bot, void *packet_struct, void *function);
 
 /* Subtract the ‘struct timeval’ values X and Y,
  * storing the result in RESULT.
@@ -199,8 +200,9 @@ void *callback_executor(void *index)
         int pid = data->packet_id;
 
         function *func = &(bot->_data->callbacks[state][pid]);
+
         while(func->next) {
-            (func->f)(bot, data);
+            packet_callback(bot, data, func->f);
             func = func->next;
         }
         free_packet(data);
@@ -270,4 +272,613 @@ void *schedule_executor(void *index)
     pipe_consumer_free(p);
 
     return NULL;
+}
+
+void packet_callback(bot_t *bot, void *packet_struct, void *function) {
+    int packet_id = ((protocol_dummy_t *)packet_struct)->packet_id;
+    switch (bot->_data->current_state) {
+        case HANDSHAKE:
+            switch (packet_id) {
+            }
+            break;
+        case LOGIN:
+            switch (packet_id) {
+            case 0x00:
+                {
+                login_clientbound_disconnect_t *p = packet_struct;
+                void (*f)(char *) = function;
+                f(p->json);
+                break;
+                }
+            case 0x02:
+                {
+                login_clientbound_success_t *p = packet_struct;
+                void (*f)(char *, char *) = function;
+                f(p->uuid, p->username);
+                break;
+                }
+            case 0x03:
+                {
+                login_clientbound_set_compression_t *p = packet_struct;
+                void (*f)(vint32_t) = function;
+                f(p->threshold);
+                break;
+                }
+            }
+            break;
+        case STATUS:
+            switch (packet_id) {
+            case 0x00:
+                {
+                status_clientbound_response_t *p = packet_struct;
+                void (*f)(char *) = function;
+                f(p->json);
+                break;
+                }
+            case 0x01:
+                {
+                status_clientbound_ping_t *p = packet_struct;
+                void (*f)(int64_t) = function;
+                f(p->time);
+                break;
+                }
+            }
+            break;
+        case PLAY:
+            switch (packet_id) {
+            case 0x00:
+                {
+                play_clientbound_keepalive_t *p = packet_struct;
+                void (*f)(vint32_t) = function;
+                f(p->keepalive_id);
+                break;
+                }
+            case 0x01:
+                {
+                play_clientbound_join_game_t *p = packet_struct;
+                void (*f)(int32_t, 
+                        uint8_t, 
+                        int8_t, 
+                        uint8_t, 
+                        uint8_t, 
+                        char*) = function;
+                f(p->entity_id,
+                        p->gamemode,
+                        p->dimension,
+                        p->difficulty,
+                        p->max_players,
+                        p->level_type);
+                break;
+                }
+            case 0x02:
+                {
+                play_clientbound_chat_t *p = packet_struct;
+                void (*f)(char *, int8_t) = function;
+                f(p->json, p->position);
+                break;
+                }
+            case 0x03:
+                {
+                play_clientbound_time_update_t *p = packet_struct;
+                void (*f)(int64_t, int64_t) = function;
+                f(p->age, p->time);
+                break;
+                }
+            case 0x04:
+                {
+                play_clientbound_entity_equipment_t *p = packet_struct;
+                void (*f)(vint32_t, int16_t, slot_t) = function;
+                f(p->entity_id, p->slot, p->item);
+                break;
+                }
+            case 0x05:
+                {
+                play_clientbound_spawn_position_t *p = packet_struct;
+                void (*f)(position_t) = function;
+                f(p->location);
+                break;
+                }
+            case 0x06:
+                {
+                play_clientbound_update_health_t *p = packet_struct;
+                void (*f)(float, vint32_t, float) = function;
+                f(p->health, p->food, p->saturation);
+                break;
+                }
+            case 0x07:
+                {
+                play_clientbound_respawn_t *p = packet_struct;
+                void (*f)(int32_t, uint8_t, uint8_t, char *) = function;
+                f(p->dimension, p->difficulty, p->gamemode, p->level_type);
+                break;
+                }
+            case 0x08:
+                {
+                play_clientbound_position_t *p = packet_struct;
+                void (*f)(double,
+                        double,
+                        double,
+                        float,
+                        float,
+                        int8_t) = function;
+                f(p->x, p->y, p->z, p->yaw, p->pitch, p->flags);
+                break;
+                }
+            case 0x09:
+                {
+                play_clientbound_item_change_t *p = packet_struct;
+                void (*f)(int8_t) = function;
+                f(p->slot);
+                break;
+                }
+            case 0x0A:
+                {
+                play_clientbound_use_bed_t *p = packet_struct;
+                void (*f)(vint32_t, position_t) = function;
+                f(p->entity_id, p->location);
+                break;
+                }
+            case 0x0B:
+                {
+                play_clientbound_animation_t *p = packet_struct;
+                void (*f)(vint32_t, uint8_t) = function;
+                f(p->entity_id, p->animation);
+                break;
+                }
+            case 0x0C:
+                {
+                play_clientbound_spawn_player_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        __uint128_t,
+                        int32_t,
+                        int32_t,
+                        int32_t,
+                        int8_t,
+                        int8_t,
+                        int16_t,
+                        metadata_t) = function;
+                f(p->entity_id,
+                        p->uuid,
+                        p->x,
+                        p->y,
+                        p->z,
+                        p->yaw,
+                        p->pitch,
+                        p->item,
+                        p->metadata);
+                break;
+                }
+            case 0x0D:
+                {
+                play_clientbound_collect_t *p = packet_struct;
+                void (*f)(vint32_t, vint32_t) = function;
+                f(p->collected_entity_id, p->collector_entity_id);
+                break;
+                }
+            case 0x0E:
+                {
+                play_clientbound_spawn_object_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int8_t,
+                        int32_t,
+                        int32_t,
+                        int32_t,
+                        int8_t,
+                        int8_t,
+                        data_t) = function;
+                f(p->entity_id,
+                        p->type,
+                        p->x,
+                        p->y,
+                        p->z,
+                        p->yaw,
+                        p->pitch,
+                        p->data);
+                break;
+                }
+            case 0x0F:
+                {
+                play_clientbound_spawn_mob_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        uint8_t,
+                        int32_t,
+                        int32_t,
+                        int32_t,
+                        int8_t,
+                        int8_t,
+                        int8_t,
+                        int16_t,
+                        int16_t,
+                        int16_t,
+                        metadata_t) = function;
+                f(p->entity_id, 
+                        p->type, 
+                        p->x, 
+                        p->y, 
+                        p->z, 
+                        p->yaw, 
+                        p->pitch,
+                        p->head_pitch,
+                        p->dx,
+                        p->dy,
+                        p->dz,
+                        p->metadata);
+                break;
+                }
+            case 0x10:
+                {
+                play_clientbound_spawn_painting_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        char *,
+                        position_t,
+                        uint8_t) = function;
+                f(p->entity_id,
+                        p->title,
+                        p->location,
+                        p->direction);
+                break;
+                }
+            case 0x11:
+                {
+                play_clientbound_spawn_xp_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int32_t,
+                        int32_t,
+                        int32_t,
+                        int16_t) = function;
+                f(p->entity_id,
+                        p->x,
+                        p->y,
+                        p->z,
+                        p->count);
+                break;
+                }
+            case 0x12:
+                {
+                play_clientbound_entity_velocity_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int16_t,
+                        int16_t,
+                        int16_t) = function;
+                f(p->entity_id,
+                        p->dx,
+                        p->dy,
+                        p->dz);
+                break;
+                }
+            case 0x13:
+                {
+                play_clientbound_entity_destroy_entities_t *p = packet_struct;
+                void (*f)(vint32_t, vint32_t *) = function;
+                f(p->count, p->entity_ids);
+                break;
+                }
+            case 0x14:
+                {
+                play_clientbound_entity_t *p = packet_struct;
+                void (*f)(vint32_t) = function;
+                f(p->entity_id);
+                break;
+                }
+            case 0x15:
+                {
+                play_clientbound_entity_move_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int8_t,
+                        int8_t,
+                        int8_t,
+                        bool) = function;
+                f(p->entity_id,
+                        p->dx,
+                        p->dy,
+                        p->dz,
+                        p->on_ground);
+                break;
+                }
+            case 0x16:
+                {
+                play_clientbound_entity_look_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int8_t,
+                        int8_t,
+                        bool,
+                        int8_t) = function;
+                f(p->entity_id,
+                        p->yaw,
+                        p->pitch,
+                        p->on_ground,
+                        p->pitch_fraction);
+                break;
+                }
+            case 0x17:
+                {
+                play_clientbound_entity_look_move_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int8_t,
+                        int8_t,
+                        int8_t,
+                        int8_t,
+                        int8_t,
+                        bool) = function;
+                f(p->entity_id,
+                        p->dx,
+                        p->dy,
+                        p->dz,
+                        p->yaw,
+                        p->pitch,
+                        p->on_ground);
+                break;
+                }
+            case 0x18:
+                {
+                play_clientbound_entity_teleport_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int32_t,
+                        int32_t,
+                        int32_t,
+                        int8_t,
+                        int8_t,
+                        bool) = function;
+                f(p->entity_id,
+                        p->x,
+                        p->y,
+                        p->z,
+                        p->yaw,
+                        p->pitch,
+                        p->on_ground);
+                break;
+                }
+            case 0x19:
+                {
+                play_clientbound_entity_head_look_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int8_t) = function;
+                f(p->entity_id, p->yaw);
+                break;
+                }
+            case 0x1A:
+                {
+                play_clientbound_entity_status_t *p = packet_struct;
+                void (*f)(int32_t,
+                        int8_t) = function;
+                f(p->entity_id, p->status);
+                break;
+                }
+            case 0x1B:
+                {
+                play_clientbound_entity_attach_t *p = packet_struct;
+                void (*f)(int32_t,
+                        int32_t,
+                        bool) = function;
+                f(p->entity_id, p->vehicle_id, p->leash);
+                break;
+                }
+            case 0x1D:
+                {
+                play_clientbound_entity_effect_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int8_t,
+                        int8_t,
+                        vint32_t,
+                        bool) = function;
+                f(p->entity_id,
+                        p->effect_id,
+                        p->amplifier,
+                        p->duration,
+                        p->hide);
+                break;
+                }
+            case 0x1E:
+                {
+                play_clientbound_entity_clear_effect_t *p = packet_struct;
+                void (*f)(vint32_t, int8_t) = function;
+                f(p->entity_id, p->effect_id);
+                break;
+                }
+            case 0x20:
+                {
+                play_clientbound_entity_properties_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int32_t,
+                        property_t *) = function;
+                f(p->entity_id, p->count, p->properties);
+                break;
+                }
+            case 0x1F:
+                {
+                play_clientbound_set_xp_t *p = packet_struct;
+                void (*f)(float, int32_t, int32_t) = function;
+                f(p->xp_bar, p->level, p->xp);
+                break;
+                }
+            case 0x21:
+                {
+                play_clientbound_chunk_data_t *p = packet_struct;
+                void (*f)(int32_t,
+                        int32_t,
+                        bool,
+                        uint16_t,
+                        vint32_t,
+                        int8_t *) = function;
+                f(p->chunk_x,
+                        p->chunk_z,
+                        p->continuous,
+                        p->bitmap,
+                        p->size,
+                        p->data);
+                break;
+                }
+            case 0x22:
+                {
+                play_clientbound_multi_block_change_t *p = packet_struct;
+                void (*f)(int32_t,
+                        int32_t,
+                        vint32_t,
+                        record_t *) = function;
+                f(p->chunk_x,
+                        p->chunk_z,
+                        p->count,
+                        p->records);
+                break;
+                }
+            case 0x23:
+                {
+                play_clientbound_block_change_t *p = packet_struct;
+                void (*f)(position_t, vint32_t) = function;
+                f(p->location, p->block_id);
+                break;
+                }
+            case 0x24:
+                {
+                play_clientbound_block_action_t *p = packet_struct;
+                void (*f)(position_t,
+                        uint8_t,
+                        uint8_t,
+                        vint32_t) = function;
+                f(p->location,
+                        p->byte1,
+                        p->byte2,
+                        p->type);
+                break;
+                }
+            case 0x25:
+                {
+                play_clientbound_block_break_animation_t *p = packet_struct;
+                void (*f)(vint32_t, position_t, int8_t) = function;
+                f(p->entity_id, p->location, p->stage);
+                break;
+                }
+            case 0x26:
+                {
+                play_clientbound_chunk_bulk_t *p = packet_struct;
+                void (*f)(bool,
+                        vint32_t,
+                        int32_t,
+                        int32_t,
+                        uint16_t,
+                        int8_t *) = function;
+                f(p->skylight,
+                        p->column_count,
+                        p->chunk_x,
+                        p->chunk_z,
+                        p->bitmap,
+                        p->data);
+                break;
+                }
+            case 0x27:
+                {
+                play_clientbound_explosion_t *p = packet_struct;
+                void (*f)(float,
+                        float,
+                        float,
+                        float,
+                        int32_t,
+                        record_t *,
+                        float,
+                        float,
+                        float) = function;
+                f(p->x,
+                        p->y,
+                        p->z,
+                        p->radius,
+                        p->count,
+                        p->records,
+                        p->dx,
+                        p->dy,
+                        p->dz);
+                break;
+                }
+            case 0x28:
+                {
+                play_clientbound_effect_t *p = packet_struct;
+                void (*f)(int32_t,
+                        position_t,
+                        int32_t,
+                        bool) = function;
+                f(p->effect_id,
+                        p->location,
+                        p->data,
+                        p->relative);
+                break;
+                }
+            case 0x29:
+                {
+                play_clientbound_sound_effect_t *p = packet_struct;
+                void (*f)(char *,
+                        int32_t,
+                        int32_t,
+                        int32_t,
+                        float,
+                        uint8_t) = function;
+                f(p->sound_name,
+                        p->x,
+                        p->y,
+                        p->z,
+                        p->volume,
+                        p->pitch);
+                break;
+                }
+            case 0x2C:
+                {
+                play_clientbound_entity_spawn_global_t *p = packet_struct;
+                void (*f)(vint32_t,
+                        int8_t,
+                        int32_t,
+                        int32_t,
+                        int32_t) = function;
+                f(p->entity_id,
+                        p->type,
+                        p->x,
+                        p->y,
+                        p->z);
+                break;
+                }
+            case 0x33:
+                {
+                play_clientbound_update_sign_t *p = packet_struct;
+                void (*f)(position_t,
+                        chat_t,
+                        chat_t,
+                        chat_t,
+                        chat_t) = function;
+                f(p->location,
+                        p->line1,
+                        p->line2,
+                        p->line3,
+                        p->line4);
+                break;
+                }
+            case 0x3F:
+                {
+                play_clientbound_plugin_message_t *p = packet_struct;
+                void (*f)(char *, int8_t *) = function;
+                f(p->channel, p->data);
+                break;
+                }
+            case 0x40:
+                {
+                play_clientbound_plugin_disconnect_t *p = packet_struct;
+                void (*f)(char *) = function;
+                f(p->reason);
+                break;
+                }
+            case 0x41:
+                {
+                play_clientbound_plugin_difficulty_t *p = packet_struct;
+                void (*f)(uint8_t) = function;
+                f(p->difficulty);
+                break;
+                }
+            case 0x46:
+                {
+                play_clientbound_set_compression_t *p = packet_struct;
+                void (*f)(vint32_t) = function;
+                f(p->threshold);
+                break;
+                }
+            }
+            break;
+        default:
+            break;
+        }
 }

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -5,38 +5,31 @@
 #include "protocol.h"
 #include <pthread.h>
 
-void login_success_handler(bot_t *bot, char *uuid, char *username)
+void mcc_login_success_handler(bot_t *bot, char *uuid, char *username)
 {
     printf("Logged in: %s\n", username);
 
-    // acquire lock
     pthread_mutex_lock(&bot->bot_mutex);
 
     bot->_data->current_state = PLAY;
 
-    // release lock
     pthread_mutex_unlock(&bot->bot_mutex);
-
-    //static char msg[64];
-    //sprintf(msg, "Hi guys, %s here.", p->username);
-    //send_play_serverbound_chat(bot, msg);
 }
 
-void keepalive_handler(bot_t *bot, vint32_t keepalive_id)
+void mcc_keepalive_handler(bot_t *bot, vint32_t keepalive_id)
 {
     send_play_serverbound_keepalive(bot, keepalive_id);
 }
 
-void join_game_handler(bot_t *bot, 
-        int32_t entity_id, 
-        uint8_t gamemode, 
-        int8_t dimension, 
-        uint8_t difficulty, 
-        uint8_t max_players, 
-        char* level_type)
+void mcc_join_game_handler(bot_t *bot,
+                           int32_t entity_id,
+                           uint8_t gamemode,
+                           int8_t dimension,
+                           uint8_t difficulty,
+                           uint8_t max_players,
+                           char* level_type)
 {
 
-    // acquire lock
     pthread_mutex_lock(&bot->bot_mutex);
 
     bot->eid = entity_id;
@@ -46,7 +39,6 @@ void join_game_handler(bot_t *bot,
     bot->max_players = max_players;
     bot->level_type = level_type;
 
-    // release lock
     pthread_mutex_unlock(&bot->bot_mutex);
 
     // Set client settings.
@@ -56,7 +48,7 @@ void join_game_handler(bot_t *bot,
     //                                     (uint8_t *)"vanilla");
 }
 
-void chat_handler(bot_t *bot, char *json, int8_t position)
+void mcc_chat_handler(bot_t *bot, char *json, int8_t position)
 {
     char *msg = NULL;
     char *sender = NULL;
@@ -78,27 +70,24 @@ void chat_handler(bot_t *bot, char *json, int8_t position)
     free(msg);
 }
 
-void update_health_handler(bot_t *bot, 
-        float health, 
-        vint32_t food, 
-        float saturation)
+void mcc_update_health_handler(bot_t *bot,
+                               float health,
+                               vint32_t food,
+                               float saturation)
 {
-    // acquire lock
     pthread_mutex_lock(&bot->bot_mutex);
 
     bot->health = (int)(health);
     bot->food = food;
     bot->saturation = saturation;
 
-    // release lock
     pthread_mutex_unlock(&bot->bot_mutex);
 }
 
-/* Rename plz */
-void respawn_handler(bot_t *bot,
-        float health,
-        vint32_t food,
-        float saturation)
+void mcc_autorespawn_handler(bot_t *bot,
+                             float health,
+                             vint32_t food,
+                             float saturation)
 {
     if (health <= 0) {
         send_play_serverbound_player_move(bot, bot->x, bot->y, bot->z, true);
@@ -106,15 +95,14 @@ void respawn_handler(bot_t *bot,
     }
 }
 
-void position_handler(bot_t *bot,
-        double x,
-        double y,
-        double z,
-        float yaw,
-        float pitch,
-        int8_t flags)
+void mcc_position_handler(bot_t *bot,
+                          double x,
+                          double y,
+                          double z,
+                          float yaw,
+                          float pitch,
+                          int8_t flags)
 {
-    // acquire lock
     pthread_mutex_lock(&bot->bot_mutex);
 
     bot->x = x;
@@ -124,7 +112,6 @@ void position_handler(bot_t *bot,
     bot->pitch = pitch;
     bot->flags = flags;
 
-    // release lock
     pthread_mutex_unlock(&bot->bot_mutex);
 
     //printf("current (x, y, z): (%f, %f, %f)\n", bot->x, bot->y, bot->z);

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -1,16 +1,17 @@
 #pragma once
 
+#include "protocol.h"
 #include "bot.h"
 
 /*
  * On a successful login, set bot state to PLAY.
  */
-void login_success_handler(bot_t *, void *);
+void mcc_login_success_handler(bot_t *bot, char *uuid, char *username);
 
 /*
  * Echo back keepalive_ids.
  */
-void keepalive_handler(bot_t *, void *);
+void mcc_keepalive_handler(bot_t *bot, vint32_t keepalive_id);
 
 /*
  * Set bot data:
@@ -21,26 +22,43 @@ void keepalive_handler(bot_t *, void *);
  *      max_players,
  *      level_type
  */
-void join_game_handler(bot_t *, void *);
+void mcc_join_game_handler(bot_t *bot, int32_t entity_id,
+                           uint8_t gamemode,
+                           int8_t dimension,
+                           uint8_t difficulty,
+                           uint8_t max_players,
+                           char* level_type);
 
 /*
  * Parse the JSON data from users or the server.
  * If the message is in the form \<command> [<arg1> <arg2> ...],
  * excecute the command with the given args.
  */
-void chat_handler(bot_t *bot, void *vp);
+void mcc_chat_handler(bot_t *bot, char *json, int8_t position);
 
 /*
  * Update bot health, food, and saturation.
  */
-void update_health_handler(bot_t *, void *);
+void mcc_update_health_handler(bot_t *bot,
+                               float health,
+                               vint32_t food,
+                               float saturation);
 
 /*
- * Auto-respawn if dead.
+ * Immediately respawn whenever dead.
  */
-void respawn_handler(bot_t *bot, void *vp);
+void mcc_autorespawn_handler(bot_t *bot,
+                             float health,
+                             vint32_t food,
+                             float saturation);
 
 /*
  * Echo position back to the server (confirm location).
  */
-void position_handler(bot_t *, void *);
+void mcc_position_handler(bot_t *bot,
+                          double x,
+                          double y,
+                          double z,
+                          float yaw,
+                          float pitch,
+                          int8_t flags);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -3,21 +3,13 @@
 #include <stdint.h>
 #include "bot.h"
 #include <stdbool.h>
+#include "types.h"
 
 #define DEFAULT_THRESHOLD (512)
 #define HANDSHAKE_PACKETS 0x0
 #define LOGIN_PACKETS 0x03
 #define PLAY_PACKETS 0x47
 #define STATUS_PACKETS 0x02
-
-typedef uint64_t position_t;
-typedef int32_t vint32_t;
-typedef char* chat_t;
-typedef int32_t data_t;
-typedef void* metadata_t;
-typedef void* property_t;
-typedef void* record_t;
-typedef void* slot_t;
 
 void *protocol_decode(bot_t *bot);
 

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,12 @@
+#pragma once
+
+typedef uint64_t position_t;
+typedef int32_t vint32_t;
+typedef char* chat_t;
+typedef int32_t data_t;
+typedef void* metadata_t;
+typedef void* property_t;
+typedef void* record_t;
+typedef void* slot_t;
+
+


### PR DESCRIPTION
Major changes:
Callback handlers do not have the same prototype 
```c
void f(bot_t * bot, void *data)
```
anymore. Now they each have their own, like
```c
void join_game(bot_t *bot, int32_t, uint8_t, int8_t, uint8_t, uint8_t, char *)
```
Consequently, there are now separate functions for registering each callback. This gives us better type safety (implying we had it to begin with).

Additionally now there's another function called packet_callback in client.c that executes the callbacks based on the packet id.

There's a lot of code, but we'll be better for it.
