### PR TITLE
Added rule 'run'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SA      = scan-build
 DIR 	:= $(shell pwd)
 
 CFLAGS  = -c -fpic -Wall -Isrc --std=gnu99
-LDFLAGS = -L$(DIR)/$(LIB) -lpthread -lm -lmcc
+LDFLAGS = -lpthread -lm
 
 SRC		= src
 LIB		= lib
@@ -22,7 +22,7 @@ SAMPLE		:= $(patsubst %.c,%.o,$(wildcard sample/*.c))
 all: $(TARGET)
 
 $(TARGET): $(SHAREDLIB) $(SAMPLE) | $(BIN)
-	$(CC) $(SAMPLE) -o $@ $(LDFLAGS)
+	$(CC) $(SAMPLE) $(OBJECTS) -o $@ $(LDFLAGS)
 
 # Rule for making all object files
 $(OBJ)/%.o: $(SRC)/%.c | $(OBJ)
@@ -34,9 +34,8 @@ $(SHAREDLIB): $(OBJECTS) | $(LIB)
 	ln $(SHAREDLIB) $(LIB)/libmcc.so
 
 .PHONY: test
-test: export LD_LIBRARY_PATH=$(DIR)/$(LIB)
 test: $(SHAREDLIB) $(TEST) | $(BIN)
-	$(CC) $(TEST) -o $(BIN)/$@ $(LDFLAGS)
+	$(CC) $(TEST) $(OBJECTS) -o $(BIN)/$@ $(LDFLAGS)
 	$(BIN)/$@
 
 # I don't understand this rule, but it works

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ $(SHAREDLIB): $(OBJECTS) | $(LIB)
 	$(CC) -shared -o $@ $(OBJECTS)
 	ln $(SHAREDLIB) $(LIB)/libmcc.so
 
-.PHONY: tests
-tests: export LD_LIBRARY_PATH=$(DIR)/$(LIB)
-tests: $(SHAREDLIB) $(TEST) | $(BIN)
+.PHONY: test
+test: export LD_LIBRARY_PATH=$(DIR)/$(LIB)
+test: $(SHAREDLIB) $(TEST) | $(BIN)
 	$(CC) $(TEST) -o $(BIN)/$@ $(LDFLAGS)
 	$(BIN)/$@
 


### PR DESCRIPTION
1. Since we are now linking our executables with lib/libmcc.so, I added more flags to LDFLAGS
2. When executables are dynamically linked, the loader needs to know where to find dependencies. We have the following options (that i can think of):
    1. Move libmcc.so to the standard library paths /lib, /usr/lib, etc.
    2. Hardcode the library path in the ELF header for the executable (rpath)
    3. Manually set the environment variable LD_LIBRARY_PATH before running the ELF binary
        e.g. $LD_LIBRARY_PATH=path/to/lib ./my_elf
    4. Make a script that wraps around all our executables and sets the variable
    5. Screw dynamic linking and go back to static linking

Option 1 and 2 are reportable beyond consideration, 3 will be a huge pain, and 5 is how we've been doing it. I sort of implemented option 4, but instead of a script I added a rule to the Makefile called 'run'. You use it like this:

make run EXEC=my_exec

And it runs the binary with the flag set.
