### PR TITLE
Refactored packet serialization and added packet throttling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ SRCFILES	= 	src/protocol.c \
 				src/base64.c \
 				src/serial.c \
 				src/capture.c \
-				src/break.c
+				src/break.c \
+				src/throttle.c \
+				src/queue.c
 
 OBJECTS 	= $(patsubst $(SRC)/%.c,$(OBJ)/%.o, $(SRCFILES))
 

--- a/break.py
+++ b/break.py
@@ -33,7 +33,6 @@ def generate_block_break_table(break_json):
     for i in range(256):
         if str(i) in break_json:
             data = break_json[str(i)]
-            print(str(i))
             code +=    '    {\n' + \
                        '        .name               = "{:s}",\n'.format(data['name']) + \
                        '        .hardness           = {:s},\n'.format(c_float_to_string(data['hardness'])) + \

--- a/include/protocol.h
+++ b/include/protocol.h
@@ -3,14 +3,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "bot.h"
+#include "serial.h"
 
 #define DEFAULT_THRESHOLD (512)
 
 
 int send_string(struct bot_agent *bot, char *str);
 
-int send_uncompressed(struct bot_agent *bot, char *data, size_t len);
-int send_compressed(struct bot_agent *bot, char *data, size_t len);
+int send_uncompressed(struct bot_agent *bot, struct packet_write_buffer *data, size_t len);
+int send_compressed(struct bot_agent *bot, struct packet_write_buffer *data, size_t len);
 
 
 int32_t send_handshaking_serverbound_handshake(

--- a/include/serial.h
+++ b/include/serial.h
@@ -2,11 +2,16 @@
 #include <stdint.h>
 #include "types.h"
 
+#define VARINT_MAXLEN   5
 
+/* Buffer with padding before the head and after the tail */
 struct packet_write_buffer {
     uint32_t capacity;
+    uint32_t headroom;
+    uint32_t tailroom;
     char *base;
-    char *ptr;
+    char *head;
+    char *tail;
 };
 
 int varint64(char *data, int32_t bytes_left, int64_t *value);
@@ -35,6 +40,11 @@ char *_read_vint32(char *buf, vint32_t *val, struct bot_agent *bot);
 char *_read_vint64(char *buf, vint64_t *val, struct bot_agent *bot);
 char *_read_string(char *buf, char **strptr, int32_t *str_len, struct bot_agent *bot);
 char *_read_slot(char *packet_raw, struct slot_type *slot_data, struct bot_agent *bot);
+void _prepend(struct packet_write_buffer *buffer, const void *data, size_t size);
+
+void _prepend_vint32(struct packet_write_buffer *buffer, vint32_t val);
+
+
 void _push(struct packet_write_buffer *buffer, const void *data, size_t size);
 void _push_int16_t(struct packet_write_buffer *buffer, int16_t val);
 void _push_uint16_t(struct packet_write_buffer *buffer, uint16_t val);
@@ -51,4 +61,4 @@ void _push_string(struct packet_write_buffer *buffer, const char *str);
 void _push_slot(struct packet_write_buffer *buffer, struct slot_type *slot_data);
 
 void pad_length(struct packet_write_buffer *buffer);
-void init_packet_write_buffer(struct packet_write_buffer *buffer, uint32_t capacity);
+void init_packet_write_buffer(struct packet_write_buffer *buffer, uint32_t capacity, uint32_t headroom);

--- a/include/types.h
+++ b/include/types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "queue.h"
+
 #include <uv.h>
 #include <stdbool.h>
 #include <zlib.h>
@@ -1088,7 +1090,6 @@ struct bot_agent {
     bool reduced_debug_info;
 
     enum state current_state;
-    int packet_id;
 
     char *name;
     struct mc_position position;
@@ -1137,6 +1138,8 @@ struct bot_agent {
     int32_t packet_bytes_read; /* how many packet bytes have been read into buffer */
     char *packet_buffer; /* the buffer into which socket stream data is copied */
     char *packet_data; /* pointer to the start of a packet within packet_buffer */
+    int32_t packet_id;
+
     /* callbacks */ 
     struct _callbacks callbacks;
 
@@ -1144,4 +1147,9 @@ struct bot_agent {
     uv_timer_t block_break_timer;
     struct mc_position block_break_location;
     int is_breaking;
+    
+    uv_timer_t packet_throttle_timer;
+    uv_thread_t packet_throttle_thread;
+    struct queue packet_throttle_queue;
+    struct timespec throttle_sleep;
 };

--- a/test.c
+++ b/test.c
@@ -7,13 +7,10 @@
 #include "protocol.h"
 #include "capture.h"
 #include "break.h"
+#include "throttle.h"
 
 #define DEFAULT_SERVER_NAME "localhost"
 #define DEFAULT_SERVER_PORT "25565"
-
-void *_read(void *buffer, void *storage, size_t size);
-void *_read_vint32(void *buffer, int32_t *val);
-void *_read_string(void *buffer, char **strptr, int32_t *len);
 
 struct player {
     char uuid[16];
@@ -248,7 +245,7 @@ void block_change_cb(
                 (int)location.z
                 );
         printf("%s", message);
-        //send_play_serverbound_chat_message(bot, message);
+        send_play_serverbound_chat_message(bot, message);
 
         snprintf(message,
                 sizeof(message),
@@ -256,7 +253,7 @@ void block_change_cb(
                 block_hardness(block_id)
                 );
         printf("%s", message);
-        //send_play_serverbound_chat_message(bot, message);
+        send_play_serverbound_chat_message(bot, message);
 
         snprintf(message,
                 sizeof(message),
@@ -264,7 +261,7 @@ void block_change_cb(
                 block_break_time_hand(block_id)
                 );
         printf("%s", message);
-        //send_play_serverbound_chat_message(bot, message);
+        send_play_serverbound_chat_message(bot, message);
         printf("    metadata: 0x%02x\n", block_id & 15);
         
         start_block_break(bot, block_id, location);
@@ -322,6 +319,7 @@ int main(int argc, char *argv[], char **envp)
     init_capture(&bot, capture_file);
 
     join_server_hostname(&bot, server_name, server_port);
+    init_throttle(&bot, 1000);
     uv_run(&bot.loop, UV_RUN_DEFAULT);
     while(1);
     uv_loop_close(&bot.loop);


### PR DESCRIPTION
1. When serializing packets to be sent to the server, we use a buffer with padding on both ends. Prepending to the packet was implemented in a disgracefully ad-hoc fashion. Now both head-room and tail-room in the packet buffer are closely and properly managed.

2. Packet throttling - for certain packets (such as chat messages), the server will disconnect the client if too many are sent at once. Now there is a send_packet_throttled() function which enqueues a packet to a bot-local queue. A timer handler dequeues these packets on an interval which is configurable.